### PR TITLE
dict and list as type validators; validation returns the correct type of instance.

### DIFF
--- a/tests.rst
+++ b/tests.rst
@@ -70,7 +70,7 @@ subclasses of dict or list::
   >>> d = Schema(dict)(Dict(a=1, b=2))
   >>> d
   {'a': 1, 'b': 2}
-  >>> isinstance(d, Dict)
+  >>> type(d) is Dict
   True
   >>> class List(list):
   ...   pass    
@@ -78,5 +78,5 @@ subclasses of dict or list::
   >>> l = Schema(list)(List([1,2,3]))
   >>> l
   [1, 2, 3]
-  >>> isinstance(l, List)
+  >>> type(l) is List
   True

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -232,7 +232,7 @@ class Schema(object):
         if not isinstance(data, dict):
             raise Invalid('expected a dictionary', path)
 
-        out = type(schema)()
+        out = type(data)()
         required_keys = set(key for key in schema
                             if
                             (self.required and not isinstance(key, optional))
@@ -309,7 +309,7 @@ class Schema(object):
         if not schema:
             return data
 
-        out = type(schema)()
+        out = type(data)()
         invalid = None
         index_path = UNDEFINED
         for i, value in enumerate(data):


### PR DESCRIPTION
1. Made dict and list work as type validators so:
   
   <pre>
     >>> Schema(dict)({'a': 1})
     {'a': 1}
     >>> Schema(list)([1,2,3])
     [1, 2, 3]
   </pre>
   
   
    Without this patch, we'd have to workaround it like this:
   
   <pre> 
    >>> any_dict = Schema({}, extra=True)
    >>> Schema(any_dict)({'a': 1})
    {'a': 1}
   </pre>
2. Validation now returns the correct type of instance for subclass of list or dict:
   
   <pre>
     >>> class Dict(dict):
     ...   pass
     >>> type(Schema(Dict)(Dict(a=1))) is Dict
     True
   </pre>
