### PR TITLE
Added default_to validation mutating function.

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -776,6 +776,20 @@ def title(v):
     return str(v).title()
 
 
+def default_to(default_value, msg=None):
+    """Sets a value to default_value if none provided.
+
+    >>> s = Schema(default_to(42))
+    >>> s(None)
+    42
+    """
+    def f(v):
+        if v is None:
+            v = default_value
+        return v
+    return f
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod()


### PR DESCRIPTION
Added `default_to` validation mutating function to set a value to a default one if none provided. Intended use case would be make sure the validated data has some sensible defaults if no value was supplied, thus simplifying subsequent logic. 

A couple simple examples:
- 1: file creation API

``` python
import voluptuous as v

file_permissions_schema = v.Schema({v.required('permissions'): v.default_to(['read', 'write'])})

user_supplied_file_permissions = {'permissions': None}
file_permissions = file_permissions_schema(user_supplied_file_permissions)
#  no need to worry about missing permissions below this point
```
- 2: paged results query API 

``` python
import voluptuous as v

results_query_schema = v.Schema({v.required('per_page'): v.default_to(100)})

user_supplied_results_query = {'per_page': None}
results_query = results_query_schema(user_supplied_results_query )
#  we have a sensible default for per_page after this point
```
