### PR TITLE
Prevent all() from overwriting its arguments

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -593,10 +593,10 @@ def all(*validators, **kwargs):
     def f(v):
         try:
             for schema in schemas:
-                v = schema(v)
+                result = schema(v)
         except Invalid, e:
             raise Invalid(msg or e.msg)
-        return v
+        return result
     return f
 
 


### PR DESCRIPTION
Currently, a validator can be a callable that raises an exception. Since there is no explicit requirement for it to return the value it was passed, it is possible for a validator that doesn't return anything when it successfully validates a value to cause a failure when used in conjunction with some other validator via the `all()` function. See the following example:

```
import voluptuous as v

def isodd(x):
    if (x % 2.0) == 0.0:
        raise ValueError

val1 = v.Schema(isodd)
val2 = v.Schema(v.range(0.0, 10.0))
val3 = v.Schema(v.all(isodd, v.range(0.0, 10.0)))

x = 3.0

# None of these should raise an exception:
val1(x)
val2(x)
val3(x)
```

The pull request prevents this problem from occurring by not recycling the variable used to pass the value being tested to each of the validators passed to the `all()` function.
