### PR TITLE
Custom message for required keys.

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -218,7 +218,7 @@ class Schema(object):
             >>> validate({'one': 'three'})
             Traceback (most recent call last):
             ...
-            InvalidList: not a valid value for dictionary value @ data['one']
+            InvalidList: not a valid value @ data['one']
 
         An invalid key:
 
@@ -295,8 +295,7 @@ class Schema(object):
                     if len(e.path) > len(key_path):
                         errors.append(e)
                     else:
-                        errors.append(Invalid(e.msg + ' for dictionary value',
-                                e.path))
+                        errors.append(Invalid(e.msg, e.path))
                     break
 
                 # Key and value okay, mark any required() fields as found.


### PR DESCRIPTION
Currently `required` class takes optional `msg` argument but it is never used. This change makes it works. 

Following example

``` python
import voluptuous as v

validate = v.Schema({v.required('one', 'required field'): 'two'})
validate({})
```

will produce

```
Traceback (most recent call last):
...
InvalidList: required field @ data['one']
```
