### PR TITLE
Removed text 'for dictionary value' from the validation message for dict

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -218,7 +218,7 @@ class Schema(object):
             >>> validate({'one': 'three'})
             Traceback (most recent call last):
             ...
-            InvalidList: not a valid value for dictionary value @ data['one']
+            InvalidList: not a valid value @ data['one']
 
         An invalid key:
 
@@ -287,8 +287,7 @@ class Schema(object):
                     if len(e.path) > len(key_path):
                         errors.append(e)
                     else:
-                        errors.append(Invalid(e.msg + ' for dictionary value',
-                                e.path))
+                        errors.append(Invalid(e.msg, e.path))
                     break
 
                 # Key and value okay, mark any required() fields as found.


### PR DESCRIPTION
Removed additional text for messages created during dictionary validation to provide consistent messages with other schema types and clean user defined messages.

Now the user defined messages are not polluted with additional text. 
Following code:

``` python
import voluptuous as v
validate = v.Schema({'one': msg('two', 'should be "two"')})
validate({'one': 'three'})
```

gives us

```
Traceback (most recent call last):
...
InvalidList: should be "two" @ data['one']
```

instead of

```
Traceback (most recent call last):
...
InvalidList: should be "two" for dictionary value @ data['one']
```
