### PR TITLE
Fix Issue #26

### DIFF
--- a/tests.rst
+++ b/tests.rst
@@ -122,3 +122,16 @@ Classes with custom metaclasses should validate as schemas::
     >>> t = schema(Thing())
     >>> type(t) is Thing
     True
+
+Schemas built with All() should give the same error as the original validator (Issue #26):
+
+    >>> schema = Schema({
+    ...   Required('items'): All([{
+    ...     Required('foo'): str
+    ...   }])
+    ... })
+
+    >>> schema({'items': [{}]})
+    Traceback (most recent call last):
+    ...
+    MultipleInvalid: required key not provided @ data['items'][0]['foo']

--- a/voluptuous/voluptuous.py
+++ b/voluptuous/voluptuous.py
@@ -651,7 +651,7 @@ def All(*validators, **kwargs):
             for schema in schemas:
                 v = schema(v)
         except Invalid as e:
-            raise Invalid(msg or e.msg)
+            raise e if msg is None else Invalid(msg)
         return v
     return f
 


### PR DESCRIPTION
All() creates a new exception, rather than reraising a failed validator; this is discussed in Issue #26.

This change contains a proposed fix.
