### PR TITLE
Coerce validator should handle TypeError exceptions

### DIFF
--- a/voluptuous/voluptuous.py
+++ b/voluptuous/voluptuous.py
@@ -682,14 +682,36 @@ def truth(f):
 def Coerce(type, msg=None):
     """Coerce a value to a type.
 
-    If the type constructor throws a ValueError, the value will be marked as
-    Invalid.
+    If the type constructor throws a ValueError or TypeError, the value
+    will be marked as Invalid.
+
+
+    Default behavior:
+
+        >>> validate = Schema(Coerce(int))
+        >>> validate(None)
+        Traceback (most recent call last):
+        ...
+        MultipleInvalid: expected int
+        >>> validate('foo')
+        Traceback (most recent call last):
+        ...
+        MultipleInvalid: expected int
+
+    With custom message:
+
+        >>> validate = Schema(Coerce(int, "moo"))
+        >>> validate('foo')
+        Traceback (most recent call last):
+        ...
+        MultipleInvalid: moo
+
     """
     @wraps(Coerce)
     def f(v):
         try:
             return type(v)
-        except ValueError:
+        except (ValueError, TypeError):
             raise Invalid(msg or ('expected %s' % type.__name__))
     return f
 
@@ -1002,7 +1024,7 @@ def DefaultTo(default_value, msg=None):
             v = default_value
         return v
     return f
-
+    
 
 if __name__ == '__main__':
     import doctest


### PR DESCRIPTION
When coercing int to None, validator fails with unexpected TypeError. IMO it would be nice to handle it TypeError along with ValueError. 
