### PR TITLE
Preserving all errors for nested fields in dicts and objects

### DIFF
--- a/tests.rst
+++ b/tests.rst
@@ -132,7 +132,7 @@ Multiple errors for nested fields in dicts and objects:
  ...     SomeObj = namedtuple('SomeObj', ('strfield', 'intfield'))
  ...     validate({'anobject': SomeObj(strfield=123, intfield='one')})
  ... except MultipleInvalid as e:
- ...     print sorted(str(i) for i in e.errors) # doctest: +NORMALIZE_WHITESPACE
+ ...     print(sorted(str(i) for i in e.errors)) # doctest: +NORMALIZE_WHITESPACE
  ["expected int for object value @ data['anobject']['intfield']",
   "expected str for object value @ data['anobject']['strfield']"]
 

--- a/voluptuous/voluptuous.py
+++ b/voluptuous/voluptuous.py
@@ -396,7 +396,7 @@ class Schema(object):
         ...         }
         ...     })
         ... except MultipleInvalid as e:
-        ...     print sorted(str(i) for i in e.errors) # doctest: +NORMALIZE_WHITESPACE
+        ...     print(sorted(str(i) for i in e.errors)) # doctest: +NORMALIZE_WHITESPACE
         ["expected int for dictionary value @ data['adict']['intfield']",
          "expected str for dictionary value @ data['adict']['strfield']"]
 


### PR DESCRIPTION
Hello! It is often needed to check all fields in a structure and return errors for all erroneous fields. This patch is attempt to achieve it.
