### PR TITLE
Upper and lower boundaries can be excluded from the range of accepted values when checking with Range

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -953,6 +953,16 @@ def Range(min=None, max=None, min_included=True, max_included=True, msg=None):
     Either min or max can be excluded from the range of accepted values.
 
     :raises Invalid: If the value is outside the range.
+
+    >>> s = Schema(Range(min=1, max=10, min_included=False))
+    >>> s(5)
+    5
+    >>> s(10)
+    10
+    >>> with raises(MultipleInvalid, 'value must be at most 10'):
+    ...   s(20)
+    >>> with raises(MultipleInvalid, 'value must be higher than 1'):
+    ...   s(1)
     """
     @wraps(Range)
     def f(v):


### PR DESCRIPTION
I needed the chance to exclude lower or upper boundaries when using the Range validator so I added this option, I also wrote some tests for the validator.
