### PR TITLE
report failing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ trigger exceptions:
 ...   raise AssertionError('MultipleInvalid not raised')
 ... except MultipleInvalid as e:
 ...   exc = e
->>> str(exc) == "extra keys not allowed @ data[1]"
+>>> str(exc) == "extra keys '1' not allowed @ data[1]"
 True
 
 ```
@@ -369,7 +369,7 @@ True
 ...   raise AssertionError('MultipleInvalid not raised')
 ... except MultipleInvalid as e:
 ...   exc = e
->>> str(exc) == "extra keys not allowed @ data[4]"
+>>> str(exc) == "extra keys '4' not allowed @ data[4]"
 True
 
 ```

--- a/tests.md
+++ b/tests.md
@@ -69,7 +69,7 @@ data:
     ... except MultipleInvalid as e:
     ...   exc = e
     >>> str(exc)
-    "extra keys not allowed @ data['two']"
+    "extra keys 'two' not allowed @ data['two']"
 
 dict, list, and tuple should be available as type validators:
 
@@ -108,7 +108,7 @@ Multiple errors are reported:
     ... except MultipleInvalid as e:
     ...   errors = sorted(e.errors, key=lambda k: str(k))
     ...   print([str(i) for i in errors])  # doctest: +NORMALIZE_WHITESPACE
-    ["extra keys not allowed @ data['three']",
+    ["extra keys 'three' not allowed @ data['three']",
      "not a valid value for dictionary value @ data['one']",
      "not a valid value for dictionary value @ data['two']"]
     >>> schema = Schema([[1], [2], [3]])
@@ -228,7 +228,7 @@ Ensure that objects with \_\_slots\_\_ supported properly:
     ... except MultipleInvalid as e:
     ...   exc = e
     >>> str(exc)
-    "extra keys not allowed @ data['page']"
+    "extra keys 'page' not allowed @ data['page']"
 
     >>> schema = Schema(Object({'q': 'one', Extra: object}))
     >>> schema(structure)

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -297,7 +297,8 @@ class Schema(object):
                     if self.extra:
                         out[key] = value
                     else:
-                        errors.append(Invalid('extra keys not allowed', key_path))
+                        errors.append(Invalid('extra keys \'%s\' not allowed' %
+                                              key, key_path))
             for key in required_keys:
                 if getattr(key, 'default', UNDEFINED) is not UNDEFINED:
                     out[key.schema] = key.default
@@ -361,7 +362,7 @@ class Schema(object):
 
         An invalid key:
 
-            >>> with raises(MultipleInvalid, "extra keys not allowed @ data['two']"):
+            >>> with raises(MultipleInvalid, "extra keys 'two' not allowed @ data['two']"):
             ...   validate({'two': 'three'})
 
 
@@ -378,7 +379,7 @@ class Schema(object):
         purely to validate that the corresponding value is of that type. It
         will not Coerce the value:
 
-            >>> with raises(MultipleInvalid, "extra keys not allowed @ data['10']"):
+            >>> with raises(MultipleInvalid, "extra keys '10' not allowed @ data['10']"):
             ...   validate({'10': 'twenty'})
 
         Wrap them in the Coerce() function to achieve this:


### PR DESCRIPTION
As a hint to user, report the key which is not passing validation in
Required().  That happens whenever someone add a key which is not
expected.
