### PR TITLE
pass flake8 + related tox configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,4 @@ setup(
     install_requires=[
         'setuptools >= 0.6b1',
     ],
-    )
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
-envlist = py26,py27
+envlist = flake8,py26,py27
+
+[flake8]
+; E501: line too long (X > 79 characters)
+ignore = E501
+exclude = .tox,.venv,build,*.egg
 
 [testenv]
 distribute = True
@@ -15,9 +20,12 @@ commands =
             --cover3-branch \
         --verbose
 
+[testenv:flake8]
+deps = flake8
+commands = flake8
+
 [testenv:py26]
 basepython = python2.6
 
 [testenv:py27]
 basepython = python2.7
-

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -146,7 +146,7 @@ class Invalid(Error):
     """
 
     def __init__(self, message, path=None, error_message=None):
-        Error.__init__(self,  message)
+        Error.__init__(self, message)
         self.path = path or []
         self.error_message = error_message or message
 
@@ -328,11 +328,12 @@ class Schema(object):
             ...   validate(Structure(one='three'))
 
         """
-        base_validate = self._compile_mapping(schema,
-            invalid_msg='for object value')
+        base_validate = self._compile_mapping(
+            schema, invalid_msg='for object value')
 
         def validate_object(path, data):
-            if schema.cls is not UNDEFINED and not isinstance(data, schema.cls):
+            if (schema.cls is not UNDEFINED
+                    and not isinstance(data, schema.cls)):
                 raise Invalid('expected a {0!r}'.format(schema.cls), path)
             iterable = _iterate_object(data)
             iterable = ifilter(lambda item: item[1] is not None, iterable)
@@ -417,8 +418,8 @@ class Schema(object):
          "expected str for dictionary value @ data['adict']['strfield']"]
 
         """
-        base_validate = self._compile_mapping(schema,
-            invalid_msg='for dictionary value')
+        base_validate = self._compile_mapping(
+            schema, invalid_msg='for dictionary value')
 
         def validate_dict(path, data):
             if not isinstance(data, dict):
@@ -982,7 +983,7 @@ def Range(min=None, max=None, min_included=True, max_included=True, msg=None):
                 raise Invalid(msg or 'value must be at least %s' % min)
         else:
             if min is not None and v <= min:
-                raise Invalid(msg or 'value must be higher than %s' %  min)
+                raise Invalid(msg or 'value must be higher than %s' % min)
         if max_included:
             if max is not None and v > max:
                 raise Invalid(msg or 'value must be at most %s' % max)


### PR DESCRIPTION
flake8 is a style utility which wrap pep8/flake8 and mccabe if availabe.
I have added a tox environnement to easily run it.

The E501 (line too long) error is ignored, it does not play well with
the inlined examples in comment blocks.

To run:

 tox -eflake8
