### PR TITLE
Fix #61

### DIFF
--- a/tests.md
+++ b/tests.md
@@ -120,6 +120,17 @@ Multiple errors are reported:
      'invalid list value @ data[1]',
      'invalid list value @ data[2]']
 
+Required fields in dictionary which are invalid should not have required :
+
+    >>> from voluptuous import *
+    >>> schema = Schema({'one': {'two': 3}}, required=True)
+    >>> try:
+    ...   schema({'one': {'two': 2}})
+    ... except MultipleInvalid as e:
+    ...   errors = e.errors
+    >>> 'required' in ' '.join([x.msg for x in errors])
+    False
+
 Multiple errors for nested fields in dicts and objects:
 
 > \>\>\> from collections import namedtuple \>\>\> validate = Schema({

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -288,6 +288,11 @@ class Schema(object):
                                     Invalid(err.msg + invalid_msg,
                                             err.path,
                                             err.msg))
+                        # If there is a validation error for a required
+                        # key, this means that the key was provided.
+                        # Discard the required key so it does not
+                        # create an additional, noisy exception.
+                        required_keys.discard(skey)
                         break
 
                     # Key and value okay, mark any Required() fields as found.
@@ -298,6 +303,7 @@ class Schema(object):
                         out[key] = value
                     else:
                         errors.append(Invalid('extra keys not allowed', key_path))
+
             for key in required_keys:
                 if getattr(key, 'default', UNDEFINED) is not UNDEFINED:
                     out[key.schema] = key.default


### PR DESCRIPTION
This prevents an Invalid error message for a key being required when in fact it has been passed in but is invalid.
