### PR TITLE
Fix default required keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,13 @@ to the second element in the schema, and succeed:
 
 ```
 
+## Running tests.
+
+Voluptuous is using nosetests:
+
+    $ nosetests
+
+
 ## Why use Voluptuous over another validation library?
 
 **Validators are simple callables**

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,39 @@
-from voluptuous import Schema, In
+from nose.tools import assert_equal
+
+import voluptuous
+from voluptuous import Schema, Required, Extra, Invalid, In
+
+
+def test_required():
+    """Verify that Required works."""
+    schema = Schema({Required('q'): 1})
+    # Can't use nose's raises (because we need to access the raised
+    # exception, nor assert_raises which fails with Python 2.6.9.
+    try:
+        schema({})
+    except Invalid as e:
+        assert_equal(str(e), "required key not provided @ data['q']")
+    else:
+        assert False, "Did not raise Invalid"
+
+
+def test_extra_with_required():
+    """Verify that Required does not break Extra."""
+    schema = Schema({Required('toaster'): str, Extra: object})
+    r = schema({'toaster': 'blue', 'another_valid_key': 'another_valid_value'})
+    assert_equal(
+        r, {'toaster': 'blue', 'another_valid_key': 'another_valid_value'})
+
+
+def test_iterate_candidates():
+    """Verify that the order for iterating over mapping candidates is right."""
+    schema = {
+        "toaster": str,
+        Extra: object,
+    }
+    # toaster should be first.
+    assert_equal(voluptuous._iterate_mapping_candidates(schema)[0][0],
+                 'toaster')
 
 
 def test_in():


### PR DESCRIPTION
If you don't explicitely pass default_required_keys in the closure, you can
get weird behavior where this variable will stay the same across multiple
runs.

Also adding unittest-style tests to ease debugging with pdb. Doctests make it
very difficult to use pdb. Not that the bug that this commit is fixing is very
difficult to reproduce.
