### PR TITLE
Allow for subclasses of Invalid to be raised by validators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ an HTTP API.
 >>> exc.path
 ['email']
 >>> exc.msg
-'This email is invalid. for dictionary value'
+'This email is invalid.'
 >>> exc.error_message
 'This email is invalid.'
 

--- a/tests.md
+++ b/tests.md
@@ -250,3 +250,19 @@ Ensure that objects can be used with other validators:
     >>> schema = Schema({'meta': Object({'q': 'one'})})
     >>> schema({'meta': Structure(q='one')})
     {'meta': Structure(q='one')}
+
+Ensure that subclasses of Invalid of are raised as is.
+
+    >>> class SpecialInvalid(Invalid):
+    ...   pass
+    ...
+    >>> def custom_validator(value):
+    ...   raise SpecialInvalid('boom')
+    ...
+    >>> schema = Schema({'thing': custom_validator})
+    >>> try:
+    ...   schema({'thing': 'not an int'})
+    ... except MultipleInvalid as e:
+    ...   exc = e
+    >>> exc.errors[0].__class__.__name__
+    'SpecialInvalid'


### PR DESCRIPTION
In response to #70, some changes here will prevent subclasses of `Invalid` raised by validators from being re-written as `Invalid`s
