### PR TITLE
Don't allow construction of dict/object schemas with duplicate keys

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_raises
 
 import voluptuous
 from voluptuous import Schema, Required, Extra, Invalid, In, Remove
@@ -77,3 +77,13 @@ def test_remove():
     schema = Schema([1.0, Remove(float), int])
     out_ = schema([1, 2, 1.0, 2.0, 3.0, 4])
     assert_equal(out_, [1, 2, 1.0, 4])
+
+
+def test_dupe_keys():
+    """Verify that constructing a schema with duplicate keys raises an error"""
+    assert_raises(voluptuous.SchemaError, Schema,
+                  {Required("id"): str, Required("id"): int})
+    assert_raises(voluptuous.SchemaError, Schema,
+                  {Required("id"): str, "id": str})
+    assert_raises(voluptuous.SchemaError, Schema,
+                  {voluptuous.Optional("id"): str, Required("id"): int})

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -390,7 +390,8 @@ class Schema(object):
         candidates = list(_iterate_mapping_candidates(_compiled_schema))
 
         keys_list = [k for k in _compiled_schema.keys()]
-        keys_set = set([k.schema if isinstance(k, Marker) else k
+        keys_set = set([k.schema if isinstance(k, Marker)
+                        and not isinstance(k, Remove) else k
                         for k in _compiled_schema.keys()])
         if len(keys_list) != len(keys_set):
             raise SchemaError('Duplicate markers')

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -389,6 +389,12 @@ class Schema(object):
 
         candidates = list(_iterate_mapping_candidates(_compiled_schema))
 
+        keys_list = [k for k in _compiled_schema.keys()]
+        keys_set = set([k.schema if isinstance(k, Marker) else k
+                        for k in _compiled_schema.keys()])
+        if len(keys_list) != len(keys_set):
+            raise SchemaError('Duplicate markers')
+
         def validate_mapping(path, iterable, out):
             required_keys = all_required_keys.copy()
             # keeps track of all default keys that haven't been filled


### PR DESCRIPTION
Inadvertently creating a schema with both Required and Optional versions of the same key creates indeterminate behaviour when validating, so it should be disallowed at schema construction.

