### PR TITLE
Improve Mapping Sort and Moved candidates Outside validate_mapping()

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -517,6 +517,8 @@ class Schema(object):
         A dictionary schema can contain a set of values, or at most one
         validator function/type.
 
+        A dictionary schema will only validate a dictionary:
+
             >>> validate = Schema({})
             >>> with raises(MultipleInvalid, 'expected a dictionary'):
             ...   validate([])


### PR DESCRIPTION
Two changes in this request:
1. Schema mapping are sorted in the following order:
   1. values
   2. `Remove`
   3. `Marker`
   4. `callable()`
   5. `type`
   6. `Extra`
2. Moved `candidates` computation outside the `validate_mapping()` function

Since there's no need to sort the `_compiled_schema` for each key in the data (which will add unnecessary overhead), it would suffice to declare `candidates` outside the validate function as:

``` python
    candidates = list(_iterate_mapping_candidates(_compiled_schema))
```

This speed up validation by a factor of ~3x on my machine
