### PR TITLE
Fixed Python 3.x version check by using sys.version_info

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -91,7 +91,7 @@ from contextlib import contextmanager
 from functools import wraps
 
 
-if sys.version > '3':
+if sys.version_info >= (3,):
     import urllib.parse as urlparse
     long = int
     unicode = str


### PR DESCRIPTION
This change fixes two things:
- Using `sys.version_info` instead of `sys.version` (the string `sys.version` should not be used as there is no guarantee the version number is at the beginning of the string).
- Comparing equal or higher than 3; presumably that's what you meant here because otherwise you're checking whether it's Python 4+.
