### PR TITLE
Added a "literal" class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,17 @@ except ImportError:
     from distutils.core import setup
 
 import sys
+import os
+import atexit
 sys.path.insert(0, '.')
 version = __import__('voluptuous').__version__
 
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
+    with open('README.rst', 'w') as f:
+        f.write(long_description)
+    atexit.register(lambda: os.unlink('README.rst'))
 except ImportError:
     print('WARNING: Could not locate pandoc, using Markdown long_description.')
     long_description = open('README.md').read()

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -91,7 +91,7 @@ from contextlib import contextmanager
 from functools import wraps
 
 
-if sys.version > '3':
+if sys.version_info >= (3,):
     import urllib.parse as urlparse
     long = int
     unicode = str
@@ -283,8 +283,9 @@ class DirInvalid(Invalid):
 class PathInvalid(Invalid):
     """The value is not a path."""
 
+
 class LiteralInvalid(Invalid):
-    """The value is not a path."""
+    """The litteral values do not match."""
 
 
 class Schema(object):
@@ -306,7 +307,7 @@ class Schema(object):
         :param extra: Specify how extra keys in the data are treated:
             - :const:`~voluptuous.PREVENT_EXTRA`: to disallow any undefined
               extra keys (raise ``Invalid``).
-            - :const:`~voluptuous.ALLOW_EXTRA`: to include underfined extra
+            - :const:`~voluptuous.ALLOW_EXTRA`: to include undefined extra
               keys in the output.
             - :const:`~voluptuous.REMOVE_EXTRA`: to exclude undefined extra keys
               from the output.
@@ -1591,10 +1592,18 @@ class Literal(object):
         self.lit = lit
 
     def __call__(self, value, msg=None):
-        if self.lit == value:
+        if self.lit != value:
             raise LiteralInvalid(
                 msg or '%s not match for %s' % (value, self.lit)
             )
+        else:
+            return self.lit
+    
+    def __str__(self):
+        return str(self.lit)
+    
+    def __repr__(self):
+        return repr(self.lit)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes you don't want Voluptuous to interpret a list or a dictionary as a schema, but as a literal. This fixes that problem.

This also fixes or provides a workaround for #96 .
