### PR TITLE
Added validator for datetime strings

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -83,6 +83,7 @@ Validate like so:
     ...                  'Users': {'snmp_community': 'monkey'}}}}
     True
 """
+import datetime
 import os
 import re
 import sys
@@ -1478,6 +1479,23 @@ def Length(min=None, max=None, msg=None):
             raise LengthInvalid(msg or 'length of value must be at least %s' % min)
         if max is not None and len(v) > max:
             raise LengthInvalid(msg or 'length of value must be at most %s' % max)
+        return v
+    return f
+
+
+class DatetimeInvalid(Invalid):
+    """The value is not a formatted datetime string."""
+
+
+def Datetime(format=None, msg=None):
+    """Validate that the value matches the datetime format."""
+    @wraps(Datetime)
+    def f(v):
+        check_format = format or '%Y-%m-%dT%H:%M:%S.%fZ'
+        try:
+            datetime.datetime.strptime(v, check_format)
+        except (TypeError, ValueError):
+            raise DatetimeInvalid(msg or 'value does not match expected format %s' % check_format)
         return v
     return f
 


### PR DESCRIPTION
This commit adds a validator for dates, times and datetimes.

If no format string is specified then ISO format will be used by default.

This resolves https://github.com/alecthomas/voluptuous/issues/98.

Example:

``` python
>>> from voluptuous import Datetime
>>> Datetime('%Y')('2014')
'2014'
>>> Datetime('%Y')('2014-01-01')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "voluptuous.py", line 1498, in f
    raise DatetimeInvalid(msg or 'value does not match expected format %s' % check_format)
voluptuous.DatetimeInvalid: value does not match expected format %Y
>>> Datetime('%Y')(1234567890)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "voluptuous.py", line 1498, in f
    raise DatetimeInvalid(msg or 'value does not match expected format %s' % check_format)
voluptuous.DatetimeInvalid: value does not match expected format %Y
```

And also:

``` python
>>> s = Schema({Required('a'): Datetime('%Y')})
>>> s({'a': 3})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "voluptuous.py", line 322, in __call__
    return self._compiled([], data)
  File "voluptuous.py", line 620, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "voluptuous.py", line 456, in validate_mapping
    raise MultipleInvalid(errors)
voluptuous.MultipleInvalid: value does not match expected format %Y for dictionary value @ data['a']
```
