### PR TITLE
Use with statement to close file handle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ try:
     atexit.register(lambda: os.unlink('README.rst'))
 except ImportError:
     print('WARNING: Could not locate pandoc, using Markdown long_description.')
-    long_description = open('README.md').read()
+    with open('README.md') as f:
+        long_description = f.read()
 
 description = long_description.splitlines()[0].strip()
 


### PR DESCRIPTION
This change ensures the file handle is closed automatically (similar to the use of the `with` statement a few lines above it).
