### PR TITLE
Don't assume a user's dict type can be instantiated.

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -627,7 +627,7 @@ class Schema(object):
             if errors:
                 raise MultipleInvalid(errors)
 
-            out = type(data)()
+            out = {}
             return base_validate(path, iteritems(data), out)
 
         return validate_dict


### PR DESCRIPTION
`validate_dict()` operates on types derived from dict and creates a new
instance using `type(data)()`. However, this only works if the type has a
default constructor. This breaks on other types, like Django's `QueryDict`
whose constructor take a positional argument.

Even types with a default constructor can be problematic if they could have side
effects.

This change creates a plain `dict` instead.