### PR TITLE
Validator for duplicates (set)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 .coverage
 .tox
 MANIFEST
+.idea


### PR DESCRIPTION
Would something like this make sense?

Our REST API defines a field that must not contain duplicates, ie. it needs to be a set. These two extra validators would allow us to ensure that the list does not contain duplicates (`Unique`) and also to convert it into a set in the end (`Set`).

Theoretically, they should support any object, that is convertible to a set. I'm not sure if that's wise, though.