### PR TITLE
Fix a TypeError when using a copy of dictionary fields.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import copy
 from nose.tools import assert_equal
 
 import voluptuous
@@ -155,3 +156,20 @@ def test_url_validation_without_host():
                      "expected a URL for dictionary value @ data['url']")
     else:
         assert False, "Did not raise Invalid for empty string url"
+
+
+def test_copy_dict_undefined():
+    """ test with a copied dictionary """
+    fields = {
+        Required("foo"): int
+    }
+    copied_fields = copy.deepcopy(fields)
+
+    schema = Schema(copied_fields)
+
+    # This used to raise a `TypeError` because the instance of `Undefined`
+    # was a copy, so object comparison would not work correctly.
+    try:
+        schema({"foo": "bar"})
+    except Exception as e:
+        assert isinstance(e, MultipleInvalid)

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -458,7 +458,7 @@ class Schema(object):
 
             # set defaults for any that can have defaults
             for key in default_keys:
-                if key.default != UNDEFINED:  # if the user provides a default with the node
+                if not isinstance(key.default, Undefined):  # if the user provides a default with the node
                     out[key.schema] = key.default()
                     if key in required_keys:
                         required_keys.discard(key)


### PR DESCRIPTION
Previously, when using a copy of a dictionary of fields,
a TypeError would be raised for invalid schemas, since
the copy of `UNDEFINED` would not be the same object.

This commit changes the comparison to `isinstance` to ensure
that copies of `UNDEFINED` are correctly recognized as undefined.