### PR TITLE
Makers should be comparable

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -173,3 +173,13 @@ def test_copy_dict_undefined():
         schema({"foo": "bar"})
     except Exception as e:
         assert isinstance(e, MultipleInvalid)
+
+
+def test_sorting():
+    """ Expect alphabetic sorting """
+    foo = Required('foo')
+    bar = Required('bar')
+    items = [foo, bar]
+    expected = [bar, foo]
+    result = sorted(items)
+    assert result == expected

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -872,6 +872,9 @@ class Marker(object):
     def __repr__(self):
         return repr(self.schema)
 
+    def __lt__(self, other):
+        return self.schema < other.schema
+
 
 class Optional(Marker):
     """Mark a node in the schema as optional, and optionally provide a default


### PR DESCRIPTION
I was using *voluptuous* in a project of mine and need to have my Schema dictionary sorted, so I implemented ``__lt__`` on the ``Marker`` class. Not sure if anyone has an opposition for this? I've included a simple test for this as well. 