### PR TITLE
Have iteritems work with any Mapping class that implements iteritems

### DIFF
--- a/voluptuous.py
+++ b/voluptuous.py
@@ -100,11 +100,11 @@ if sys.version_info >= (3,):
     unicode = str
     basestring = str
     ifilter = filter
-    iteritems = dict.items
+    iteritems_attr = 'items'
 else:
     from itertools import ifilter
     import urlparse
-    iteritems = dict.iteritems
+    iteritems_attr = 'iteritems'
 
 
 __author__ = 'Alec Thomas <alec@swapoff.org>'
@@ -137,6 +137,11 @@ def default_factory(value):
     if value is UNDEFINED or callable(value):
         return value
     return lambda: value
+
+
+def iteritems(mapping):
+  """Return iteritems for Mappings."""
+  return getattr(mapping, iteritems_attr)()
 
 
 # options for extra keys


### PR DESCRIPTION
This is helpful for cases where we want to validate objects which are dictionary-like but might not have the same implementation for iteritems as a dict. Could be related to #125 

$ nosetests
........................................................
----------------------------------------------------------------------
Ran 56 tests in 0.132s
OK