### PR TITLE
Schema default parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,28 @@ True
 
 ```
 
+#### Overriding Schema defaults for required and extra
+
+If all your schema dictionaries use the same non-default required/extra
+options, you can change the default globally for all future Schema instances:
+
+```pycon
+>>> from voluptuous import Schema, PREVENT_EXTRA, REMOVE_EXTRA
+>>> Schema.DEFAULT_REQUIRED = True
+>>> Schema.DEFAULT_EXTRA = REMOVE_EXTRA
+>>> s = Schema({'needed': 1})
+>>> s.required
+True
+>>> s({'needed': 1, 'removed': 2})
+{'needed': 1}
+>>> Schema.DEFAULT_REQUIRED = False
+>>> Schema.DEFAULT_EXTRA = PREVENT_EXTRA
+>>> Schema({'foo': 1}).required
+False
+
+
+```
+
 ### Extending an existing Schema
 
 Often it comes handy to have a base `Schema` that is extended with more

--- a/tests.py
+++ b/tests.py
@@ -209,3 +209,22 @@ def test_schema_extend_overrides():
     assert base.extra == voluptuous.PREVENT_EXTRA
     assert extended.required == False
     assert extended.extra == voluptuous.ALLOW_EXTRA
+
+
+def test_schema_default_parameters():
+    """Schema default parameters can be changed"""
+
+    schema = Schema(1)
+    assert schema.required == False
+    assert schema.extra == voluptuous.PREVENT_EXTRA
+
+    Schema.DEFAULT_REQUIRED = True
+    Schema.DEFAULT_EXTRA = voluptuous.REMOVE_EXTRA
+
+    schema = Schema(1)
+    assert schema.required == True
+    assert schema.extra == voluptuous.REMOVE_EXTRA
+
+    # Restore defaults for other tests
+    Schema.DEFAULT_REQUIRED = False
+    Schema.DEFAULT_EXTRA = voluptuous.PREVENT_EXTRA

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,5 @@
 import copy
-from nose.tools import assert_equal
+from nose.tools import assert_equal, with_setup
 
 import voluptuous
 from voluptuous import (
@@ -211,6 +211,12 @@ def test_schema_extend_overrides():
     assert extended.extra == voluptuous.ALLOW_EXTRA
 
 
+def restore_schema_defaults():
+    Schema.DEFAULT_REQUIRED = False
+    Schema.DEFAULT_EXTRA = voluptuous.PREVENT_EXTRA
+
+
+@with_setup(teardown=restore_schema_defaults)
 def test_schema_default_parameters():
     """Schema default parameters can be changed"""
 
@@ -224,7 +230,3 @@ def test_schema_default_parameters():
     schema = Schema(1)
     assert schema.required == True
     assert schema.extra == voluptuous.REMOVE_EXTRA
-
-    # Restore defaults for other tests
-    Schema.DEFAULT_REQUIRED = False
-    Schema.DEFAULT_EXTRA = voluptuous.PREVENT_EXTRA

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -310,8 +310,10 @@ class Schema(object):
     in which case an isinstance() check is performed, or callables, which will
     validate and optionally convert the value.
     """
+    DEFAULT_REQUIRED = False
+    DEFAULT_EXTRA = PREVENT_EXTRA
 
-    def __init__(self, schema, required=False, extra=PREVENT_EXTRA):
+    def __init__(self, schema, required=None, extra=None):
         """Create a new Schema.
 
         :param schema: Validation schema. See :module:`voluptuous` for details.
@@ -327,8 +329,8 @@ class Schema(object):
               :const:`~voluptuous.PREVENT_EXTRA`
         """
         self.schema = schema
-        self.required = required
-        self.extra = int(extra)  # ensure the value is an integer
+        self.required = self.DEFAULT_REQUIRED if required is None else required
+        self.extra = self.DEFAULT_EXTRA if extra is None else int(extra)  # ensure the value is an integer
         self._compiled = self._compile(schema)
 
     def __call__(self, data):


### PR DESCRIPTION
As per discussion in issue #103.

The README.md part is still a bit hairy, as the defaults need to be restored there too. Which leaves me wondering if this is really the right way to go about this. I don't know if it would be better to have some factory method that would return a new class equal to `Schema` but with different defaults.

Not sure if it would make any improvement to the user API though.

But yeah, this should work too, unless you have better ideas.