### PR TITLE
add AnySequence validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,33 @@ attribute-value pair in the corresponding object:
 
 ```
 
+### Exact Sequence
+
+To validate an exact sequence of items, the `ExactSequence` validator is
+provided.
+
+```pycon
+>>> from voluptuous import ExactSequence
+>>> schema = Schema(ExactSequence(['one', 'two', int]))
+>>> schema(['one', 'two', 3])
+['one', 'two', 3]
+>>> try:
+...   schema([1, 2, 3])
+...   raise AssertionError('MultipleInvalid not raised')
+... except MultipleInvalid as e:
+...   exc = e
+>>> str(exc) == 'not a valid value'
+True
+>>> try:
+...   schema([3, 'two', 'one'])
+...   raise AssertionError('MultipleInvalid not raised')
+... except MultipleInvalid as e:
+...   exc = e
+>>> str(exc) == 'not a valid value'
+True
+
+```
+
 ### Any Sequence
 
 The `AnySequence` validator is provided for validating an array of items that

--- a/README.md
+++ b/README.md
@@ -429,6 +429,37 @@ attribute-value pair in the corresponding object:
 
 ```
 
+### Any Sequence
+
+The `AnySequence` validator is provided for validating an array of items that
+may have any order. An optional kwarg, `extra`, which defaults to
+`voluptuous.PREVENT_EXTRA` can be used to modify the type of validation done.
+- `PREVENT_EXTRA`: output and schema will have equal length
+- `ALLOW_EXTRA`: output and schema may have unequal length
+- `REMOVE_EXTRA`: remove items from output after all schema validated
+
+```pycon
+>>> from voluptuous import AnySequence
+>>> from voluptuous import PREVENT_EXTRA, ALLOW_EXTRA, REMOVE_EXTRA
+>>> schema = Schema(AnySequence([int, 'two', 'one']))
+>>> try:
+...   schema([3, 'two', 'one', 'zero'])
+...   raise AssertionError('MultipleInvalid not raised')
+... except MultipleInvalid as e:
+...   exc = e
+>>> str(exc) == 'input and schema lengths unequal'
+True
+>>> schema = Schema(AnySequence(['one', 'two', int], extra=ALLOW_EXTRA))
+>>> schema([3, 'two', 'one'])
+['one', 'two', 3]
+>>> schema([3, 'two', 'one', 'two'])
+['one', 'two', 'two', 3]
+>>> schema = Schema(AnySequence([int, 'two', 'one'], extra=REMOVE_EXTRA))
+>>> schema([3, 'two', 'one', 'zero'])
+[3, 'two', 'one']
+
+```
+
 ### Allow None values
 
 To allow value to be None as well, use Any:


### PR DESCRIPTION
AnySequence validates a sequence of items in any order.  With the internal sequence validator I get an unexpected exception unless I concatenate all the sublists into a single list (and subdicts into a single dict, etc.).  Should this also/rather be fixed?
```pycon
>>> schema = Schema([1, 2], [3, 4])
>>> try:
...   schema([[1, 2], [3, 4]])
...   raise AssertionError('MultipleInvalid not raised')
... except MultipleInvalid as e:
...   exc = e
>>> str(exc) == 'invalid list value @ data[0]'
True
>>> schema = Schema([[1, 2, 3, 4]])
>>> schema([[1, 2], [3, 4]])
[[1, 2], [3, 4]]
```
```pycon
>>> schema = Schema(AnySequence([[1, 2], [3, 4]]))
True
>>> schema([[1, 2], [3, 4]])
[[1, 2], [3, 4]]
```