### PR TITLE
Add NotIn validation

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -4,7 +4,7 @@ from nose.tools import assert_equal
 import voluptuous
 from voluptuous import (
     Schema, Required, Extra, Invalid, In, Remove, Literal,
-    Url, MultipleInvalid, LiteralInvalid
+    Url, MultipleInvalid, LiteralInvalid, NotIn
 )
 
 
@@ -44,6 +44,18 @@ def test_in():
     """Verify that In works."""
     schema = Schema({"color": In(frozenset(["blue", "red", "yellow"]))})
     schema({"color": "blue"})
+
+
+def test_not_in():
+    """Verify that NotIn works."""
+    schema = Schema({"color": NotIn(frozenset(["blue", "red", "yellow"]))})
+    schema({"color": "orange"})
+    try:
+        schema({"color": "blue"})
+    except Invalid as e:
+        assert_equal(str(e), "value is not allowed for dictionary value @ data['color']")
+    else:
+        assert False, "Did not raise NotInInvalid"
 
 
 def test_remove():

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -1584,6 +1584,24 @@ def In(container, msg=None):
     return validator
 
 
+class NotInInvalid(Invalid):
+    pass
+
+
+def NotIn(container, msg=None):
+    """Validate that a value is not in a collection."""
+    @wraps(NotIn)
+    def validator(value):
+        try:
+            check = value in container
+        except TypeError:
+            check = True
+        if check:
+            raise NotInInvalid(msg or 'value is not allowed')
+        return value
+    return validator
+
+
 def Lower(v):
     """Transform a string to lower case.
 


### PR DESCRIPTION
Relatively self explanitory, this is a valdiator that ensures values
are not in a given collection of values, e.g.

    schema = Schema({"color": NotIn(frozenset(["blue", "red", "yellow"]))})
    schema({"color": "orange"})  # valid
    schema({"color": "blue"})  # invalid

