### PR TITLE
Run static analysis on the exact source set

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:flake8]
 deps = flake8
-commands = flake8
+commands = flake8 setup.py voluptuous.py tests.py
 
 [testenv:py26]
 basepython = python2.6


### PR DESCRIPTION
It prevents running flake8 on the entire virtualenv when located at top source directory.