### PR TITLE
Handle nested MultipleInvalid exceptions.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -264,6 +264,27 @@ def test_list_validation_messages():
         assert False, "Did not raise Invalid"
 
 
+def test_nested_multiple_validation_errors():
+    """ Make sure useful error messages are available """
+
+    def is_even(value):
+        if value % 2:
+            raise Invalid('%i is not even' % value)
+        return value
+
+    schema = Schema(dict(even_numbers=All([All(int, is_even)],
+                                          Length(min=1))))
+
+    try:
+        schema(dict(even_numbers=[3]))
+    except Invalid as e:
+        assert_equal(len(e.errors), 1, e.errors)
+        assert_equal(str(e.errors[0]), "3 is not even @ data['even_numbers'][0]")
+        assert_equal(str(e), "3 is not even @ data['even_numbers'][0]")
+    else:
+        assert False, "Did not raise Invalid"
+
+
 def test_fix_157():
     s = Schema(All([Any('one', 'two', 'three')]), Length(min=1))
     assert_equal(['one'], s(['one']))

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -180,6 +180,9 @@ class Invalid(Error):
             output += ' for ' + self.error_type
         return output + path
 
+    def prepend(self, path):
+        self.path = path + self.path
+
 
 class MultipleInvalid(Invalid):
     def __init__(self, errors=None):
@@ -205,6 +208,10 @@ class MultipleInvalid(Invalid):
 
     def __str__(self):
         return str(self.errors[0])
+
+    def prepend(self, path):
+        for error in self.errors:
+            error.prepend(path)
 
 
 class RequiredFieldInvalid(Invalid):
@@ -788,12 +795,8 @@ def _compile_scalar(schema):
                 return schema(data)
             except ValueError as e:
                 raise ValueInvalid('not a valid value', path)
-            except MultipleInvalid as e:
-                for error in e.errors:
-                    error.path[0:0] = path
-                raise
             except Invalid as e:
-                e.path[0:0] = path
+                e.prepend(path)
                 raise
         return validate_callable
 


### PR DESCRIPTION
Previously, this would result in an "AttributeError: can't set attribute" from trying to modify the path property on MultipleInvalid.