### PR TITLE
Url's validation bug resolved

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -135,6 +135,20 @@ def test_url_validation():
     assert 'http://example.com/', out_.get("url")
 
 
+def test_url_without_prefix():
+    """ test with invalid domain """
+    schema = Schema({"url": Url()})
+    url_without_domain = 'http://example/'
+
+    try:
+        schema({"url": url_without_domain})
+    except MultipleInvalid as e:
+        assert_equal(str(e),
+                     "expected a URL for dictionary value @ data['url']")
+    else:
+        assert False, "Did not raise Invalid for domainless url"
+
+
 def test_url_validation_with_none():
     """ test with invalid None url"""
     schema = Schema({"url": Url()})

--- a/voluptuous.py
+++ b/voluptuous.py
@@ -1472,7 +1472,7 @@ def Url(v):
     """
     try:
         parsed = urlparse.urlparse(v)
-        if not parsed.scheme or not parsed.netloc:
+        if not parsed.scheme or not parsed.netloc or "." not in parsed.netloc:
             raise UrlInvalid("must have a URL scheme and host")
         return v
     except:


### PR DESCRIPTION
Earlier `http://example/` was taken as a valid url. Modified so that it is returned as invalid url.