### PR TITLE
provide basic humanize-error wrappers for #140

### DIFF
--- a/voluptuous/humanize.py
+++ b/voluptuous/humanize.py
@@ -1,0 +1,39 @@
+from voluptuous import Invalid, MultipleInvalid
+from voluptuous.error import Error
+
+
+MAX_VALIDATION_ERROR_ITEM_LENGTH = 500
+
+
+def _nested_getitem(data, path):
+    for item_index in path:
+        try:
+            data = data[item_index]
+        except (KeyError, IndexError):
+            # The index is not present in the dictionary, list or other indexable
+            return None
+    return data
+
+
+def humanize_error(data, validation_error, max_sub_error_length=MAX_VALIDATION_ERROR_ITEM_LENGTH):
+    """ Provide a more helpful + complete validation error message than that provided automatically
+    Invalid and MultipleInvalid do not include the offending value in error messages,
+    and MultipleInvalid.__str__ only provides the first error.
+    """
+    if isinstance(validation_error, MultipleInvalid):
+        return '\n'.join(sorted(
+            humanize_error(data, sub_error, max_sub_error_length)
+            for sub_error in validation_error.errors
+        ))
+    else:
+        offending_item_summary = repr(_nested_getitem(data, validation_error.path))
+        if len(offending_item_summary) > max_sub_error_length:
+            offending_item_summary = offending_item_summary[:max_sub_error_length - 3] + '...'
+        return '%s. Got %s' % (validation_error, offending_item_summary)
+
+
+def validate_with_humanized_errors(data, schema, max_sub_error_length=MAX_VALIDATION_ERROR_ITEM_LENGTH):
+    try:
+        return schema(data)
+    except (Invalid, MultipleInvalid) as e:
+        raise Error(humanize_error(data, e, max_sub_error_length))

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -6,6 +6,7 @@ from voluptuous import (
     Url, MultipleInvalid, LiteralInvalid, NotIn, Match, Email,
     Replace, Range, Coerce, All, Any, Length, FqdnUrl, ALLOW_EXTRA, PREVENT_EXTRA
 )
+from voluptuous.humanize import humanize_error
 
 
 def test_required():
@@ -381,6 +382,27 @@ def test_nested_multiple_validation_errors():
         assert_equal(str(e), "3 is not even @ data['even_numbers'][0]")
     else:
         assert False, "Did not raise Invalid"
+
+
+def test_humanize_error():
+    data = {
+        'a': 'not an int',
+        'b': [123]
+    }
+    schema = Schema({
+        'a': int,
+        'b': [str]
+    })
+    try:
+        schema(data)
+    except MultipleInvalid as e:
+        assert_equal(
+            humanize_error(data, e),
+            "expected int for dictionary value @ data['a']. Got 'not an int'\n"
+            "expected str @ data['b'][0]. Got 123"
+        )
+    else:
+        assert False, 'Did not raise MultipleInvalid'
 
 
 def test_fix_157():


### PR DESCRIPTION
The humanization wrapper includes the invalid value in the message and also combines all of the messages for a MultipleInvalid.
Landing this would satisfy #140 