### PR TITLE
Add python 3.5 to tox.ini test suite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py26,py27
+envlist = flake8,py26,py27,py35
 
 [flake8]
 ; E501: line too long (X > 79 characters)
@@ -29,3 +29,6 @@ basepython = python2.6
 
 [testenv:py27]
 basepython = python2.7
+
+[testenv:py35]
+basepython = python3.5


### PR DESCRIPTION
Since there are python 3 versions in travis.yml, adding at least one here will make it easier to test python 3 compatibility in development.