### PR TITLE
Add validate_schema decorator

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -1016,3 +1016,17 @@ def message(default=None, cls=None):
         return check
 
     return decorator
+
+
+def validate_schema(*a, **kw):
+    schema = Schema(*a, **kw)
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            result = f(*args, **kwargs)
+            schema(result)
+            return result
+        return wrapper
+
+    return decorator

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -4,7 +4,8 @@ from nose.tools import assert_equal, assert_raises
 from voluptuous import (
     Schema, Required, Extra, Invalid, In, Remove, Literal,
     Url, MultipleInvalid, LiteralInvalid, NotIn, Match, Email,
-    Replace, Range, Coerce, All, Any, Length, FqdnUrl, ALLOW_EXTRA, PREVENT_EXTRA
+    Replace, Range, Coerce, All, Any, Length, FqdnUrl, ALLOW_EXTRA, PREVENT_EXTRA,
+    validate_schema,
 )
 from voluptuous.humanize import humanize_error
 
@@ -409,3 +410,12 @@ def test_fix_157():
     s = Schema(All([Any('one', 'two', 'three')]), Length(min=1))
     assert_equal(['one'], s(['one']))
     assert_raises(MultipleInvalid, s, ['four'])
+
+
+def test_schema_decorator():
+    @validate_schema(int)
+    def fn(arg):
+        return arg
+
+    fn(1)
+    assert_raises(Invalid, fn, 1.0)


### PR DESCRIPTION
I am trying out `voluptuous` to validate the result of some functions but I couldn't find any decorator to validate schemas. This pull request adds a `validate_schema` decorator to `schema_builder.py`.

In my case, I want to define a function and specify what the return should be like, such as static typing but more powerful.

Example:

```python
@validate_schema(int)
def fn(arg):
    return arg

fn(1)  # this returns the result of `fn(1)` untouched
fn(2.0)  # this raises an exception because the schema validation failed (expected `int`, got `float`)
```

vs

```python
schema = Schema(int)

def fn(arg):
    return arg

schema(fn(1))
schema(fn(2.0))
```