### PR TITLE
Add Equal validator

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -5,7 +5,7 @@ from voluptuous import (
     Schema, Required, Extra, Invalid, In, Remove, Literal,
     Url, MultipleInvalid, LiteralInvalid, NotIn, Match, Email,
     Replace, Range, Coerce, All, Any, Length, FqdnUrl, ALLOW_EXTRA, PREVENT_EXTRA,
-    validate_schema, ExactSequence
+    validate_schema, ExactSequence, Equal
 )
 from voluptuous.humanize import humanize_error
 
@@ -435,3 +435,19 @@ def test_schema_decorator():
 def test_range_exlcudes_nan():
     s = Schema(Range(min=0, max=10))
     assert_raises(MultipleInvalid, s, float('nan'))
+
+
+def test_equal():
+    s = Schema(Equal(1))
+    s(1)
+    assert_raises(Invalid, s, 2)
+    s = Schema(Equal('foo'))
+    s('foo')
+    assert_raises(Invalid, s, 'bar')
+    s = Schema(Equal([1, 2]))
+    s([1, 2])
+    assert_raises(Invalid, s, [])
+    assert_raises(Invalid, s, [1, 2, 3])
+    # Evaluates exactly, not through validators
+    s = Schema(Equal(str))
+    assert_raises(Invalid, s, 'foo')

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -691,3 +691,32 @@ class Unique(object):
 
     def __repr__(self):
         return 'Unique()'
+
+
+class Equal(object):
+    """Ensure that value matches target.
+
+    >>> s = Schema(Equal(1))
+    >>> s(1)
+    1
+    >>> with raises(Invalid):
+    ...    s(2)
+
+    Validators are not supported, match must be exact:
+
+    >>> s = Schema(Equal(str))
+    >>> with raises(Invalid):
+    ...     s('foo')
+    """
+
+    def __init__(self, target, msg=None):
+        self.target = target
+        self.msg = msg
+
+    def __call__(self, v):
+        if v != self.target:
+            raise Invalid(self.msg or 'Values are not equal: value:{} != target:{}'.format(v, self.target))
+        return v
+
+    def __repr__(self):
+        return 'Equal({})'.format(self.target)


### PR DESCRIPTION
Adds a validator for matching equal values, e.g. `Equal([])`. Saves you from typing `All(list, Length(max=0))`. Or maybe `Equal({})` when you have `extra=True`.