### PR TITLE
Fix empty list evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,25 @@ in the schema list is compared to each value in the input data:
 
 ```
 
+However, an empty list (`[]`) is treated as is. If you want to specify a list that can
+contain anything, specify it as `list`:
+
+```pycon
+>>> schema = Schema([])
+>>> schema([1])  # doctest: +IGNORE_EXCEPTION_DETAIL
+Traceback (most recent call last):
+    ...
+MultipleInvalid: not a valid value
+>>> schema([])
+[]
+>>> schema = Schema(list)
+>>> schema([])
+[]
+>>> schema([1, 2])
+[1, 2]
+
+```
+
 ### Validation functions
 
 Validators are simple callables that raise an `Invalid` exception when

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -203,7 +203,7 @@ class Schema(object):
             return self._compile_object(schema)
         if isinstance(schema, collections.Mapping):
             return self._compile_dict(schema)
-        elif isinstance(schema, list):
+        elif isinstance(schema, list) and len(schema):
             return self._compile_list(schema)
         elif isinstance(schema, tuple):
             return self._compile_tuple(schema)

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -479,3 +479,9 @@ def test_unordered():
     assert_raises(Invalid, s, [3, 2])
     s = Schema(Unordered([3, int]))
     s([3, 2])
+
+
+def test_empty_list_as_exact():
+    s = Schema([])
+    assert_raises(Invalid, s, [1])
+    s([])


### PR DESCRIPTION
Empty lists are now regarded as is. If a free-form list is needed, use 'list'.

Fix for #198.