### PR TITLE
Handle non-subscriptable path in humanize_error

### DIFF
--- a/voluptuous/humanize.py
+++ b/voluptuous/humanize.py
@@ -9,11 +9,10 @@ def _nested_getitem(data, path):
     for item_index in path:
         try:
             data = data[item_index]
-        except (KeyError, IndexError):
-            # The index is not present in the dictionary, list or other indexable
+        except (KeyError, IndexError, TypeError):
+            # The index is not present in the dictionary, list or other
+            # indexable or data is not subscriptable
             return None
-        except TypeError: # data is not subscriptable
-            break
     return data
 
 

--- a/voluptuous/humanize.py
+++ b/voluptuous/humanize.py
@@ -12,6 +12,8 @@ def _nested_getitem(data, path):
         except (KeyError, IndexError):
             # The index is not present in the dictionary, list or other indexable
             return None
+        except TypeError: # data is not subscriptable
+            break
     return data
 
 


### PR DESCRIPTION
### Description
_nested_getitem currently raises an exception when the error path contains a non-subscriptable entity (e.g. None, int)

```python
data = None, path = ['input_select', 'hello', 'options', 0]

    def _nested_getitem(data, path):
        for item_index in path:
            try:
>               data = data[item_index]
E               TypeError: 'NoneType' object is not subscriptable

../hv/lib64/python3.4/site-packages/voluptuous/humanize.py:11: TypeError
```

This happens in the following situations:
Data to be validated: `{'key1': None}` or `{'key1': 1}`
Schema: `vol.Schema('key1': vol.All(ensure_list, [str]))`

`ensure_list` mutates the data into an array, if [str] fails the exception contains [0] as an index in the mutated data, but the exception can only be logged using the original (non-list) data, in which case [0] cannot be applied to a non-subscriptable path like int[0] or None[0].
