### PR TITLE
Added ValidationState object to prevent duplication of reference types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ MANIFEST
 .idea
 venv
 docs/_build
+.vscode/

--- a/README.md
+++ b/README.md
@@ -558,8 +558,8 @@ an HTTP API.
 ...     exc = e
 >>> str(exc)
 "This email is invalid. for dictionary value @ data['email']"
->>> exc.path
-['email']
+>>> exc.state
+<ValidationState @ data['email']>
 >>> exc.msg
 'This email is invalid.'
 >>> exc.error_message

--- a/voluptuous/humanize.py
+++ b/voluptuous/humanize.py
@@ -27,7 +27,7 @@ def humanize_error(data, validation_error, max_sub_error_length=MAX_VALIDATION_E
             for sub_error in validation_error.errors
         ))
     else:
-        offending_item_summary = repr(_nested_getitem(data, validation_error.path))
+        offending_item_summary = repr(_nested_getitem(data, validation_error.state))
         if len(offending_item_summary) > max_sub_error_length:
             offending_item_summary = offending_item_summary[:max_sub_error_length - 3] + '...'
         return '%s. Got %s' % (validation_error, offending_item_summary)

--- a/voluptuous/tests/tests.md
+++ b/voluptuous/tests/tests.md
@@ -52,9 +52,11 @@ Errors should be reported depth-first:
     ...   validate({'one': {'four': 'six'}})
     ... except Invalid as e:
     ...   print(e)
-    ...   print(e.path)
+    ...   print(repr(e.state))
+    ...   print(e.state)
     not a valid value for dictionary value @ data['one']['four']
-    ['one', 'four']
+    <ValidationState @ data['one']['four']>
+     @ data['one']['four']
 
 Voluptuous supports validation when extra fields are present in the
 data:

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -644,7 +644,7 @@ def test_unicode_key_is_converted_to_utf8_when_in_marker():
 
 def test_number_validation_with_string():
     """ test with Number with string"""
-    schema = Schema({"number" : Number(precision=6, scale=2)})
+    schema = Schema({"number": Number(precision=6, scale=2)})
     try:
         schema({"number": 'teststr'})
     except MultipleInvalid as e:
@@ -667,7 +667,7 @@ def test_unicode_key_is_converted_to_utf8_when_plain_text():
 
 def test_number_validation_with_invalid_precision_invalid_scale():
     """ test with Number with invalid precision and scale"""
-    schema = Schema({"number" : Number(precision=6, scale=2)})
+    schema = Schema({"number": Number(precision=6, scale=2)})
     try:
         schema({"number": '123456.712'})
     except MultipleInvalid as e:
@@ -679,28 +679,28 @@ def test_number_validation_with_invalid_precision_invalid_scale():
 
 def test_number_validation_with_valid_precision_scale_yield_decimal_true():
     """ test with Number with valid precision and scale"""
-    schema = Schema({"number" : Number(precision=6, scale=2, yield_decimal=True)})
+    schema = Schema({"number": Number(precision=6, scale=2, yield_decimal=True)})
     out_ = schema({"number": '1234.00'})
     assert_equal(float(out_.get("number")), 1234.00)
 
 
 def test_number_when_precision_scale_none_yield_decimal_true():
     """ test with Number with no precision and scale"""
-    schema = Schema({"number" : Number(yield_decimal=True)})
+    schema = Schema({"number": Number(yield_decimal=True)})
     out_ = schema({"number": '12345678901234'})
     assert_equal(out_.get("number"), 12345678901234)
 
 
 def test_number_when_precision_none_n_valid_scale_case1_yield_decimal_true():
     """ test with Number with no precision and valid scale case 1"""
-    schema = Schema({"number" : Number(scale=2, yield_decimal=True)})
+    schema = Schema({"number": Number(scale=2, yield_decimal=True)})
     out_ = schema({"number": '123456789.34'})
     assert_equal(float(out_.get("number")), 123456789.34)
 
 
 def test_number_when_precision_none_n_valid_scale_case2_yield_decimal_true():
     """ test with Number with no precision and valid scale case 2 with zero in decimal part"""
-    schema = Schema({"number" : Number(scale=2, yield_decimal=True)})
+    schema = Schema({"number": Number(scale=2, yield_decimal=True)})
     out_ = schema({"number": '123456789012.00'})
     assert_equal(float(out_.get("number")), 123456789012.00)
 
@@ -712,7 +712,7 @@ def test_to_utf8():
 
 def test_number_when_precision_none_n_invalid_scale_yield_decimal_true():
     """ test with Number with no precision and invalid scale"""
-    schema = Schema({"number" : Number(scale=2, yield_decimal=True)})
+    schema = Schema({"number": Number(scale=2, yield_decimal=True)})
     try:
         schema({"number": '12345678901.234'})
     except MultipleInvalid as e:
@@ -724,14 +724,14 @@ def test_number_when_precision_none_n_invalid_scale_yield_decimal_true():
 
 def test_number_when_valid_precision_n_scale_none_yield_decimal_true():
     """ test with Number with no precision and valid scale"""
-    schema = Schema({"number" : Number(precision=14, yield_decimal=True)})
+    schema = Schema({"number": Number(precision=14, yield_decimal=True)})
     out_ = schema({"number": '1234567.8901234'})
     assert_equal(float(out_.get("number")), 1234567.8901234)
 
 
 def test_number_when_invalid_precision_n_scale_none_yield_decimal_true():
     """ test with Number with no precision and invalid scale"""
-    schema = Schema({"number" : Number(precision=14, yield_decimal=True)})
+    schema = Schema({"number": Number(precision=14, yield_decimal=True)})
     try:
         schema({"number": '12345674.8901234'})
     except MultipleInvalid as e:
@@ -743,7 +743,7 @@ def test_number_when_invalid_precision_n_scale_none_yield_decimal_true():
 
 def test_number_validation_with_valid_precision_scale_yield_decimal_false():
     """ test with Number with valid precision, scale and no yield_decimal"""
-    schema = Schema({"number" : Number(precision=6, scale=2, yield_decimal=False)})
+    schema = Schema({"number": Number(precision=6, scale=2, yield_decimal=False)})
     out_ = schema({"number": '1234.00'})
     assert_equal(out_.get("number"), '1234.00')
 
@@ -770,3 +770,21 @@ def test_date():
     schema({"date": "2016-10-24"})
     assert_raises(MultipleInvalid, schema, {"date": "2016-10-2"})
     assert_raises(MultipleInvalid, schema, {"date": "2016-10-24Z"})
+
+
+def test_references():
+    mouse = Schema({"name": str, "birthday": Date()})
+    mice = Schema([mouse])
+    schema = Schema({
+        "as value": mouse,
+        "in list": mice
+    })
+    mickey = dict(name="Mickey", birthday="1928-11-18")
+    data = {"as value": mickey,
+            "in list": [mickey, mickey]
+            }
+    out = schema(data)
+    copy1 = out["as value"]
+    copy2, copy3 = out["in list"]
+    assert copy1 is copy2, 'they are not the same ({}) != ({})'.format(id(copy1), id(copy2))
+    assert copy1 is copy3, 'they are not the same ({}) != ({})'.format(id(copy1), id(copy3))

--- a/voluptuous/validation_state.py
+++ b/voluptuous/validation_state.py
@@ -1,0 +1,83 @@
+import collections
+import copy
+from functools import wraps
+
+
+def check_cache(validator_func):
+    @wraps(validator_func)
+    def state_wrapper(state, data):
+        if isinstance(state, list):
+            path = state
+            state = ValidationState()
+            state += path
+        return state.check_cache(validator_func, data)
+    return state_wrapper
+
+
+class StateValidator(object):
+    """Interface that is used to determine a special kind of callable object
+
+    Subclasses of this class must implement __call__ consistent with the original
+    signature. The provided signature allows one to pass the state to sub-validators.
+    """
+
+    def __call__(self, data, state=None):
+        raise NotImplementedError
+
+
+class ValidationState(object):
+    """State of the validation, includes the path and cache.
+
+    This class acts a lot like a list.
+
+    The ValidationState _path is generally constant for the life of an instance.
+    Instead of adding to the _path, a new instance is created with a unique path,
+    but a shared cache.
+    """
+
+    def __init__(self, state=None):
+        if state is None:
+            self._path = []
+            self._cache = collections.defaultdict(dict)
+
+        elif isinstance(state, ValidationState):
+            # prevent modification of higher path
+            self._path = list(state._path)
+            # build on "parent" cache
+            self._cache = state._cache
+
+        else:
+            raise TypeError('Cannot initialize ValidationState with {}'.format(state))
+
+    def __repr__(self):
+        return '<ValidationState{}>'.format(self)
+
+    def __str__(self):
+        if self._path:
+            return ' @ data[%s]' % ']['.join(map(repr, self._path))
+        else:
+            return ''
+
+    def check_cache(self, validator_func, data):
+        data_id = id(data)
+        func_cache = self._cache[validator_func]
+        if data_id not in func_cache:
+            func_cache[data_id] = validator_func(self, data)
+        return func_cache[data_id]
+
+    def __add__(self, other):
+        result = ValidationState(self)
+        if isinstance(other, list):
+            result._path += other
+        elif isinstance(other, ValidationState):
+            result._path += other._path
+        else:
+            raise ValueError("Cannot add other (type={}) to ValidationState"
+                             .format(type(other)))
+        return result
+
+    def __iter__(self):
+        return iter(self._path)
+
+    def __len__(self):
+        return len(self._path)


### PR DESCRIPTION
If you like the idea, I suspect there will be lots of change requests including possible redesign. So, I kinda just want to get it started. I can also merge it with my current pull request (#256) to remove some duplicate stuff (editor formatting and `.vscode/` in `.gitignore`.

The concept is effectively to short circuit previously validated values to prevent duplication of reference types (see #253).

## Design considerations
I tried to maintain backward compatibility pretty much everywhere. I changed the use of `path`, typically used in `validation_func(path, data)` declarations to a variable called `state`, which is an instance of a `ValidatiaonState`. A `ValidationState` is a list-like object that contains two attributes:
1. `_path`  -- this is synonymous with the original `path` variable that was passed around before
2. `_cache` -- this is a nested (2-layer) `dict` with primary keys of "compiled" validation funcs, secondary keys of the original data `id` with values being the validated result (typically referred to as `out`). This is to say that the `_cache` is dependent on two things which should limit false short circuits:
2.1. the validation function used
2.2. the `id()` of the original data

I also tried to modify as little code as possible, but due to the scope it is still pretty significant. To reduce introduced code, I created the `validation_state.check_cache` decorator that is used to decorate all validation functions. This kept things relatively DRY, but could still probably be improved further.

## things I don't like
* Originally, I tried just passing `path`, and `cache` thinking that would result in the minimal amount of changes, but things got out of hand pretty quickly and method signatures got more and more ugly.
* I created an "interface" `StateValidator` that defines the `__call__(self, data, state=None)`. The interface class isn't really required, but I needed to differentiate between a generic `callable` and objects that would pass state through.
* the "compiled" functions generated in `schema_builder.py` still have _old_ signatures with `path` replaced by `state`, e.g. `validate_dict(state, data)`. I am not a fan of the inconsistency between `StateValidator.__call__` and the validation functions. Specifically, one is `(state, data)` and the other is `(data, state)`. I'd prefer to make them all `(data, state)`.