### PR TITLE
Remove unicode translation

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -283,17 +283,12 @@ class Schema(object):
                 additional_candidates.append((skey, (ckey, cvalue)))
 
         def validate_mapping(path, iterable, out):
-            try:
-                from util import to_utf8_py2
-            except ImportError:
-                from .util import to_utf8_py2
             required_keys = all_required_keys.copy()
             # keeps track of all default keys that haven't been filled
             default_keys = all_default_keys.copy()
             error = None
             errors = []
             for key, value in iterable:
-                key = to_utf8_py2(key)
                 key_path = path + [key]
                 remove_key = False
 
@@ -885,11 +880,6 @@ class Marker(object):
     """Mark nodes for special treatment."""
 
     def __init__(self, schema_, msg=None):
-        try:
-            from util import to_utf8_py2
-        except ImportError:
-            from .util import to_utf8_py2
-        schema_ = to_utf8_py2(schema_)
         self.schema = schema_
         self._schema = Schema(schema_)
         self.msg = msg

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1,5 +1,6 @@
 import copy
 import collections
+import sys
 from nose.tools import assert_equal, assert_raises, assert_true
 
 from voluptuous import (
@@ -9,7 +10,7 @@ from voluptuous import (
     validate, ExactSequence, Equal, Unordered, Number, Maybe, Datetime, Date,
     Contains, Marker)
 from voluptuous.humanize import humanize_error
-from voluptuous.util import to_utf8_py2, u
+from voluptuous.util import u
 
 
 def test_exact_sequence():
@@ -642,15 +643,13 @@ def test_schema_decorator_return_only_unmatch():
     assert_raises(Invalid, fn, 1)
 
 
-def test_unicode_key_is_converted_to_utf8_when_in_marker():
-    """Verify that when using unicode key the 'u' prefix is not thrown in the exception"""
-    schema = Schema({Required(u('q')): 1})
-    # Can't use nose's raises (because we need to access the raised
-    # exception, nor assert_raises which fails with Python 2.6.9.
-    try:
-        schema({})
-    except Invalid as e:
-        assert_equal(str(e), "required key not provided @ data['q']")
+def test_unicode_as_key():
+    if sys.version_info >= (3,):
+        text_type = str
+    else:
+        text_type = unicode
+    schema = Schema({text_type: int})
+    schema({u("foobar"): 1})
 
 
 def test_number_validation_with_string():
@@ -663,17 +662,6 @@ def test_number_validation_with_string():
                      "Value must be a number enclosed with string for dictionary value @ data['number']")
     else:
         assert False, "Did not raise Invalid for String"
-
-
-def test_unicode_key_is_converted_to_utf8_when_plain_text():
-    key = u('q')
-    schema = Schema({key: int})
-    # Can't use nose's raises (because we need to access the raised
-    # exception, nor assert_raises which fails with Python 2.6.9.
-    try:
-        schema({key: 'will fail'})
-    except Invalid as e:
-        assert_equal(str(e), "expected int for dictionary value @ data['q']")
 
 
 def test_number_validation_with_invalid_precision_invalid_scale():
@@ -714,11 +702,6 @@ def test_number_when_precision_none_n_valid_scale_case2_yield_decimal_true():
     schema = Schema({"number": Number(scale=2, yield_decimal=True)})
     out_ = schema({"number": '123456789012.00'})
     assert_equal(float(out_.get("number")), 123456789012.00)
-
-
-def test_to_utf8():
-    s = u('hello')
-    assert_true(isinstance(to_utf8_py2(s), str))
 
 
 def test_number_when_precision_none_n_invalid_scale_yield_decimal_true():

--- a/voluptuous/util.py
+++ b/voluptuous/util.py
@@ -152,12 +152,6 @@ class Literal(object):
         return repr(self.lit)
 
 
-def to_utf8_py2(data):
-    if sys.version_info < (3,) and isinstance(data, unicode):
-        return data.encode('utf-8')
-    return data
-
-
 def u(x):
     if sys.version_info < (3,):
         return unicode(x)


### PR DESCRIPTION
Unicode translation added in commit added in
5e3bf148b48bf6a9e24743b5178cdede1b78853a heavily broke Python 2. A basic test
such as provided in test_unicode_as_key in this patch does not work anymore
because of that conversion.

This patches goes back to the behaviour that was in 0.9.