### PR TITLE
Better old-style class support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- [#279](https://github.com/alecthomas/voluptuous/pull/279):
+  Treat Python 2 old-style classes like types when validating.
+
 ## [0.10.5]
 
 - [#278](https://github.com/alecthomas/voluptuous/pull/278): Unicode

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -237,7 +237,7 @@ class Schema(object):
         elif isinstance(schema, tuple):
             return self._compile_tuple(schema)
         type_ = type(schema)
-        if type_ is type:
+        if inspect.isclass(schema):
             type_ = schema
         if type_ in (bool, bytes, int, long, str, unicode, float, complex, object,
                      list, dict, type(None)) or callable(schema):
@@ -700,7 +700,7 @@ def _compile_scalar(schema):
     >>> with raises(er.Invalid, 'not a valid value'):
     ...   _compile_scalar(lambda v: float(v))([], 'a')
     """
-    if isinstance(schema, type):
+    if inspect.isclass(schema):
         def validate_instance(path, data):
             if isinstance(data, schema):
                 return data

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -5,7 +5,7 @@ from nose.tools import assert_equal, assert_raises, assert_true
 
 from voluptuous import (
     Schema, Required, Optional, Extra, Invalid, In, Remove, Literal,
-    Url, MultipleInvalid, LiteralInvalid, NotIn, Match, Email,
+    Url, MultipleInvalid, LiteralInvalid, TypeInvalid, NotIn, Match, Email,
     Replace, Range, Coerce, All, Any, Length, FqdnUrl, ALLOW_EXTRA, PREVENT_EXTRA,
     validate, ExactSequence, Equal, Unordered, Number, Maybe, Datetime, Date,
     Contains, Marker)
@@ -149,6 +149,39 @@ def test_literal():
         assert_equal(str(e), "{'b': 1} not match for {'a': 1}")
         assert_equal(len(e.errors), 1)
         assert_equal(type(e.errors[0]), LiteralInvalid)
+    else:
+        assert False, "Did not raise Invalid"
+
+
+def test_class():
+    class C1(object):
+        pass
+
+    schema = Schema(C1)
+    schema(C1())
+
+    try:
+        schema(None)
+    except MultipleInvalid as e:
+        assert_equal(str(e), "expected C1")
+        assert_equal(len(e.errors), 1)
+        assert_equal(type(e.errors[0]), TypeInvalid)
+    else:
+        assert False, "Did not raise Invalid"
+
+    # In Python 2, this will be an old-style class (classobj instance)
+    class C2:
+        pass
+
+    schema = Schema(C2)
+    schema(C2())
+
+    try:
+        schema(None)
+    except MultipleInvalid as e:
+        assert_equal(str(e), "expected C2")
+        assert_equal(len(e.errors), 1)
+        assert_equal(type(e.errors[0]), TypeInvalid)
     else:
         assert False, "Did not raise Invalid"
 


### PR DESCRIPTION
Treat old-style classes like types when validating.  Prior to this patch, old-style classes in Python 2 would be treated like callables, leading to unexpected behavior.

```
>>> from plistlib import Data  # old-style class from standard library
>>> from voluptuous import Schema
>>> schema = Schema(Data)
>>> schema(Data('abc'))
Data(Data('abc'))
>>> schema('abc')
Data('abc')
```

With this patch, old-style classes are treated the same as types.  This leads to better consistency between new-style and old-style classes.
```
>>> from plistlib import Data  # old-style class from standard library
>>> from voluptuous import Schema
>>> schema = Schema(Data)
>>> schema(Data('abc'))
Data('abc')
>>> schema('abc')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "voluptuous/schema_builder.py", line 225, in __call__
    raise er.MultipleInvalid([e])
voluptuous.error.MultipleInvalid: expected Data
```