### PR TITLE
Allow all schemas in Maybe

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -552,8 +552,12 @@ def test_maybe():
     s = Schema(Maybe(int))
     assert s(1) == 1
     assert s(None) is None
-
     assert_raises(Invalid, s, 'foo')
+
+    s = Schema(Maybe({str: Coerce(int)}))
+    assert s({'foo': '100'}) == {'foo': 100}
+    assert s(None) is None
+    assert_raises(Invalid, s, {'foo': 'bar'})
 
 
 def test_empty_list_as_exact():

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -549,8 +549,6 @@ def test_unordered():
 
 
 def test_maybe():
-    assert_raises(TypeError, Maybe, lambda x: x)
-
     s = Schema(Maybe(int))
     assert s(1) == 1
     assert s(None) is None

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -472,9 +472,10 @@ def PathExists(v):
 
 
 class Maybe(object):
-    """Validate that the object is of a given type or is None.
+    """Validate that the object matches given validator or is None.
 
-    :raises Invalid: if the value is not of the type declared and is not None
+    :raises Invalid: if the value does not match the given validator and is not
+        None
 
     >>> s = Schema(Maybe(int))
     >>> s(10)
@@ -484,21 +485,15 @@ class Maybe(object):
 
     """
 
-    def __init__(self, kind, msg=None):
-        if not isinstance(kind, type):
-            raise TypeError("kind has to be a type")
-
-        self.kind = kind
-        self.msg = msg
+    def __init__(self, validator):
+        self.validator = validator
+        self.schema = Any(None, validator)
 
     def __call__(self, v):
-        if v is not None and not isinstance(v, self.kind):
-            raise Invalid(self.msg or "%s must be None or of type %s" % (v, self.kind))
-
-        return v
+        return self.schema(v)
 
     def __repr__(self):
-        return 'Maybe(%s)' % str(self.kind)
+        return 'Maybe(%s)' % self.validator
 
 
 class Range(object):


### PR DESCRIPTION
The `Maybe` validator is only limited to types now. With this change it will be backwards compatible but also allow any type of schema to be passed in.

My only concern is that i don't know what to do with the msg parameter and so for my initial version I have removed it. We could make `__call__` be something like this:

```python
try:
    return self.schema(v)
except Invalid:
    if self.msg is None:
        raise
    raise Invalid(self.msg)
```