### PR TITLE
absolute import

### DIFF
--- a/voluptuous/__init__.py
+++ b/voluptuous/__init__.py
@@ -1,15 +1,9 @@
 # flake8: noqa
 
-try:
-    from schema_builder import *
-    from validators import *
-    from util import *
-    from error import *
-except ImportError:
-    from .schema_builder import *
-    from .validators import *
-    from .util import *
-    from .error import *
+from voluptuous.schema_builder import *
+from voluptuous.validators import *
+from voluptuous.util import *
+from voluptuous.error import *
 
 __version__ = '0.10.5'
 __author__ = 'tusharmakkar08'

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -6,11 +6,7 @@ import sys
 from contextlib import contextmanager
 
 import itertools
-
-try:
-    import error as er
-except ImportError:
-    from . import error as er
+from voluptuous import error as er
 
 if sys.version_info >= (3,):
     long = int

--- a/voluptuous/util.py
+++ b/voluptuous/util.py
@@ -1,13 +1,8 @@
 import sys
 
-try:
-    from error import LiteralInvalid, TypeInvalid, Invalid
-    from schema_builder import Schema, default_factory, raises
-    import validators
-except ImportError:
-    from .error import LiteralInvalid, TypeInvalid, Invalid
-    from .schema_builder import Schema, default_factory, raises
-    from . import validators
+from voluptuous.error import LiteralInvalid, TypeInvalid, Invalid
+from voluptuous.schema_builder import Schema, default_factory, raises
+from voluptuous import validators
 
 __author__ = 'tusharmakkar08'
 

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -5,18 +5,11 @@ import sys
 from functools import wraps
 from decimal import Decimal, InvalidOperation
 
-try:
-    from schema_builder import Schema, raises, message
-    from error import (MultipleInvalid, CoerceInvalid, TrueInvalid, FalseInvalid, BooleanInvalid, Invalid, AnyInvalid,
-                       AllInvalid, MatchInvalid, UrlInvalid, EmailInvalid, FileInvalid, DirInvalid, RangeInvalid,
-                       PathInvalid, ExactSequenceInvalid, LengthInvalid, DatetimeInvalid, DateInvalid, InInvalid,
-                       TypeInvalid, NotInInvalid, ContainsInvalid)
-except ImportError:
-    from .schema_builder import Schema, raises, message
-    from .error import (MultipleInvalid, CoerceInvalid, TrueInvalid, FalseInvalid, BooleanInvalid, Invalid, AnyInvalid,
-                        AllInvalid, MatchInvalid, UrlInvalid, EmailInvalid, FileInvalid, DirInvalid, RangeInvalid,
-                        PathInvalid, ExactSequenceInvalid, LengthInvalid, DatetimeInvalid, DateInvalid, InInvalid,
-                        TypeInvalid, NotInInvalid, ContainsInvalid)
+from voluptuous.schema_builder import Schema, raises, message
+from voluptuous.error import (MultipleInvalid, CoerceInvalid, TrueInvalid, FalseInvalid, BooleanInvalid, Invalid,
+                              AnyInvalid, AllInvalid, MatchInvalid, UrlInvalid, EmailInvalid, FileInvalid, DirInvalid,
+                              RangeInvalid, PathInvalid, ExactSequenceInvalid, LengthInvalid, DatetimeInvalid,
+                              DateInvalid, InInvalid, TypeInvalid, NotInInvalid, ContainsInvalid)
 
 if sys.version_info >= (3,):
     import urllib.parse as urlparse


### PR DESCRIPTION
It is very likely to get package conflict when using relative import like 'from error import *' in python3, so I think it's time to use absolute import 😄 

here is an example:
.
├── \_\_init\_\_.py
├── error.py
└── my_app.py (only one line in this file `import voluptuous`)

then if you run `python3 my_app.py`  will get an error:

```
AttributeError: module 'error' has no attribute 'Invalid'
```



