### PR TITLE
Fix Coerce validator to catch decimal.InvalidOperation

### DIFF
--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -92,7 +92,7 @@ class Coerce(object):
     def __call__(self, v):
         try:
             return self.type(v)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, InvalidOperation):
             msg = self.msg or ('expected %s' % self.type_name)
             raise CoerceInvalid(msg)
 


### PR DESCRIPTION
For some reason Python std lib has inconsistency in handling invalid values for numeric types:

```
>>> float('abc')
ValueError: could not convert string to float: abc
>>> int('abc')
ValueError: invalid literal for int() with base 10: 'abc'
>>> Fraction('abc')
ValueError: Invalid literal for Fraction: 'abc'
>>> Decimal('abc')
decimal.InvalidOperation: Invalid literal for Decimal: 'abc'
```

So this PR is to add `InvalidOperation` exception for `Decimal` type when using `Coerce` validator.