### PR TITLE
Declare support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 - pypy
 install:
 - pip install coveralls

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py26,py27,py35
+envlist = flake8,py26,py27,py35,py36
 
 [flake8]
 ; E501: line too long (X > 79 characters)
@@ -32,3 +32,6 @@ basepython = python2.7
 
 [testenv:py35]
 basepython = python3.5
+
+[testenv:py36]
+basepython = python3.6


### PR DESCRIPTION
- Add 3.6 to the Travis-CI and tox configurations
- Add 3.6 language classifier to `setup.py`