### PR TITLE
Drop support for end-of-life Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.6'
 - '2.7'
 - '3.3'
 - '3.4'

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py26,py27,py35,py36
+envlist = flake8,py27,py35,py36
 
 [flake8]
 ; E501: line too long (X > 79 characters)
@@ -23,9 +23,6 @@ commands =
 [testenv:flake8]
 deps = flake8
 commands = flake8 --doctests setup.py voluptuous
-
-[testenv:py26]
-basepython = python2.6
 
 [testenv:py27]
 basepython = python2.7


### PR DESCRIPTION
Per the [dev guide](https://docs.python.org/devguide/#status-of-python-branches), the following versions have been end of lifed:

- 2.6: 2013-10-29
- 3.1: 2012-04-11
- 3.2: 2016-02-20

Removing support for EOL versions should make future maintenance easier.