### PR TITLE
thb/fix-283

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ contain anything, specify it as `list`:
 ...   raise AssertionError('MultipleInvalid not raised')
 ... except MultipleInvalid as e:
 ...   exc = e
->>> str(exc) == "not a valid value"
+>>> str(exc) == "not a valid value @ data[1]"
 True
 >>> schema([])
 []

--- a/README.md
+++ b/README.md
@@ -368,28 +368,6 @@ token `extra` as a key:
 
 ```
 
-However, an empty dict (`{}`) is treated as is. If you want to specify a list that can
-contain anything, specify it as `dict`:
-
-```pycon
->>> schema = Schema({}, extra=ALLOW_EXTRA)  # don't do this
->>> try:
-...   schema({'extra': 1})
-...   raise AssertionError('MultipleInvalid not raised')
-... except MultipleInvalid as e:
-...   exc = e
->>> str(exc) == "not a valid value"
-True
->>> schema({})
-{}
->>> schema = Schema(dict)  # do this instead
->>> schema({})
-{}
->>> schema({'extra': 1})
-{'extra': 1}
-
-```
-
 #### Required dictionary keys
 
 By default, keys in the schema are not required to be in the data:

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -228,7 +228,7 @@ class Schema(object):
             return self._compile_object(schema)
         if isinstance(schema, collections.Mapping):
             return self._compile_dict(schema)
-        elif isinstance(schema, list) and len(schema):
+        elif isinstance(schema, list):
             return self._compile_list(schema)
         elif isinstance(schema, tuple):
             return self._compile_tuple(schema)
@@ -551,6 +551,10 @@ class Schema(object):
 
             # Empty seq schema, allow any data.
             if not schema:
+                if data:
+                    raise er.MultipleInvalid([
+                        er.ValueInvalid('not a valid value', [value]) for value in data
+                    ])
                 return data
 
             out = []

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -226,7 +226,7 @@ class Schema(object):
             return lambda _, v: v
         if isinstance(schema, Object):
             return self._compile_object(schema)
-        if isinstance(schema, collections.Mapping) and len(schema):
+        if isinstance(schema, collections.Mapping):
             return self._compile_dict(schema)
         elif isinstance(schema, list) and len(schema):
             return self._compile_list(schema)
@@ -408,7 +408,7 @@ class Schema(object):
 
         A dictionary schema will only validate a dictionary:
 
-            >>> validate = Schema({'prop': str})
+            >>> validate = Schema({})
             >>> with raises(er.MultipleInvalid, 'expected a dictionary'):
             ...   validate([])
 
@@ -423,6 +423,7 @@ class Schema(object):
             >>> with raises(er.MultipleInvalid, "extra keys not allowed @ data['two']"):
             ...   validate({'two': 'three'})
 
+
         Validation function, in this case the "int" type:
 
             >>> validate = Schema({'one': 'two', 'three': 'four', int: str})
@@ -432,17 +433,10 @@ class Schema(object):
             >>> validate({10: 'twenty'})
             {10: 'twenty'}
 
-        An empty dictionary is matched as value:
-
-            >>> validate = Schema({})
-            >>> with raises(er.MultipleInvalid, 'not a valid value'):
-            ...   validate([])
-
         By default, a "type" in the schema (in this case "int") will be used
         purely to validate that the corresponding value is of that type. It
         will not Coerce the value:
 
-            >>> validate = Schema({'one': 'two', 'three': 'four', int: str})
             >>> with raises(er.MultipleInvalid, "extra keys not allowed @ data['10']"):
             ...   validate({'10': 'twenty'})
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -566,40 +566,6 @@ def test_empty_list_as_exact():
     s([])
 
 
-def test_empty_dict_as_exact():
-    # {} always evaluates as {}
-    s = Schema({})
-    assert_raises(Invalid, s, {'extra': 1})
-    s = Schema({}, extra=ALLOW_EXTRA)  # this should not be used
-    assert_raises(Invalid, s, {'extra': 1})
-
-    # {...} evaluates as Schema({...})
-    s = Schema({'foo': int})
-    assert_raises(Invalid, s, {'foo': 1, 'extra': 1})
-    s = Schema({'foo': int}, extra=ALLOW_EXTRA)
-    s({'foo': 1, 'extra': 1})
-
-    # dict matches {} or {...}
-    s = Schema(dict)
-    s({'extra': 1})
-    s({})
-    s = Schema(dict, extra=PREVENT_EXTRA)
-    s({'extra': 1})
-    s({})
-
-    # nested {} evaluate as {}
-    s = Schema({
-        'inner': {}
-    }, extra=ALLOW_EXTRA)
-    assert_raises(Invalid, s, {'inner': {'extra': 1}})
-    s({})
-    s = Schema({
-        'inner': Schema({}, extra=ALLOW_EXTRA)
-    })
-    assert_raises(Invalid, s, {'inner': {'extra': 1}})
-    s({})
-
-
 def test_schema_decorator_match_with_args():
     @validate(int)
     def fn(arg):


### PR DESCRIPTION
This PR revert PR #215 to address #283. To make things more consistent, make an empty list raise an exception like an empty dict.

So an empty dict gets its `path` variable back:
```python
>>> from voluptuous import Schema
>>> Schema({})({"extra": "invalid", "extra2": "invalid", })
Traceback (most recent call last):
...
voluptuous.error.MultipleInvalid: extra keys not allowed @ data['extra2']
```
And now an empty list also raise a MultipleInvalid exception and set the `path` variable:
```python
>>> from voluptuous import Schema
>>> Schema([])(['list_invalid', 'list_invalid2'])
Traceback (most recent call last):
...
voluptuous.error.MultipleInvalid: not a valid value @ data['list_invalid']
```