### PR TITLE
add Schema.infer method

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -222,6 +222,8 @@ class Schema(object):
             },
             'baz': [str]
         }
+
+        Note: only very basic inference is supported.
         """
         def value_to_schema_type(value):
             if isinstance(value, dict):


### PR DESCRIPTION
This introduces the class method Schema.infer, to infer a Schema from
concrete data. This will be useful for converting existing known-good
data (e.g. API responses) into enforceable schemas.