### PR TITLE
make Schema.__eq__ deterministic

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -246,6 +246,9 @@ class Schema(object):
             return False
         return other.schema == self.schema
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def __str__(self):
         return str(self.schema)
 

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -242,10 +242,9 @@ class Schema(object):
         return cls(value_to_schema_type(data), **kwargs)
 
     def __eq__(self, other):
-        if str(other) == str(self.schema):
-            # Because repr is combination mixture of object and schema
-            return True
-        return False
+        if not isinstance(other, Schema):
+            return False
+        return other.schema == self.schema
 
     def __str__(self):
         return str(self.schema)

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -410,6 +410,27 @@ def test_subschema_extension():
     assert_equal(extended.schema, {'a': {'b': str, 'c': float, 'e': int}, 'd': str})
 
 
+def test_equality():
+    assert_equal(Schema('foo'), Schema('foo'))
+
+    assert_equal(Schema(['foo', 'bar', 'baz']),
+                 Schema(['foo', 'bar', 'baz']))
+
+    # Ensure two Schemas w/ two equivalent dicts initialized in a different
+    # order are considered equal.
+    dict_a = {}
+    dict_a['foo'] = 1
+    dict_a['bar'] = 2
+    dict_a['baz'] = 3
+
+    dict_b = {}
+    dict_b['baz'] = 3
+    dict_b['bar'] = 2
+    dict_b['foo'] = 1
+
+    assert_equal(Schema(dict_a), Schema(dict_b))
+
+
 def test_repr():
     """Verify that __repr__ returns valid Python expressions"""
     match = Match('a pattern', msg='message')

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -3,7 +3,7 @@ import collections
 import os
 import sys
 
-from nose.tools import assert_equal, assert_raises, assert_true
+from nose.tools import assert_equal, assert_false, assert_raises, assert_true
 
 from voluptuous import (
     Schema, Required, Exclusive, Optional, Extra, Invalid, In, Remove, Literal,
@@ -429,6 +429,17 @@ def test_equality():
     dict_b['foo'] = 1
 
     assert_equal(Schema(dict_a), Schema(dict_b))
+
+
+def test_equality_negative():
+    """Verify that Schema objects are not equal to string representations"""
+    assert_false(Schema('foo') == 'foo')
+
+    assert_false(Schema(['foo', 'bar']) == "['foo', 'bar']")
+    assert_false(Schema(['foo', 'bar']) == Schema("['foo', 'bar']"))
+
+    assert_false(Schema({'foo': 1, 'bar': 2}) == "{'foo': 1, 'bar': 2}")
+    assert_false(Schema({'foo': 1, 'bar': 2}) == Schema("{'foo': 1, 'bar': 2}"))
 
 
 def test_repr():

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -442,6 +442,37 @@ def test_equality_negative():
     assert_false(Schema({'foo': 1, 'bar': 2}) == Schema("{'foo': 1, 'bar': 2}"))
 
 
+def test_inequality():
+    assert_true(Schema('foo') != 'foo')
+
+    assert_true(Schema(['foo', 'bar']) != "['foo', 'bar']")
+    assert_true(Schema(['foo', 'bar']) != Schema("['foo', 'bar']"))
+
+    assert_true(Schema({'foo': 1, 'bar': 2}) != "{'foo': 1, 'bar': 2}")
+    assert_true(Schema({'foo': 1, 'bar': 2}) != Schema("{'foo': 1, 'bar': 2}"))
+
+
+def test_inequality_negative():
+    assert_false(Schema('foo') != Schema('foo'))
+
+    assert_false(Schema(['foo', 'bar', 'baz']) !=
+                 Schema(['foo', 'bar', 'baz']))
+
+    # Ensure two Schemas w/ two equivalent dicts initialized in a different
+    # order are considered equal.
+    dict_a = {}
+    dict_a['foo'] = 1
+    dict_a['bar'] = 2
+    dict_a['baz'] = 3
+
+    dict_b = {}
+    dict_b['baz'] = 3
+    dict_b['bar'] = 2
+    dict_b['foo'] = 1
+
+    assert_false(Schema(dict_a) != Schema(dict_b))
+
+
 def test_repr():
     """Verify that __repr__ returns valid Python expressions"""
     match = Match('a pattern', msg='message')


### PR DESCRIPTION
This adds a test to highlight the issue raised in #315 and proposes a solution: instead of comparing `str(self.schema)` with `str(other)`, just compare `schema` attributes directly.