### PR TITLE
Implement nested schema support and validators compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,21 +455,6 @@ True
 
 ```
 
-This only works if `Self` is used in the `Schema` directly. If you use `Any`,
-`All` or `SomeOf`, this won't work as they compile their arguments down to a
-new `Schema`. In that case, you can use an external reference:
-
-```pycon
->>> from voluptuous import Schema, Any
->>> def s2(v):
-...     return s1(v)
-...
->>> s1 = Schema({"key": Any(s2, "value")})
->>> s1({"key": {"key": "value"}})
-{'key': {'key': 'value'}}
-
-```
-
 ### Extending an existing Schema
 
 Often it comes handy to have a base `Schema` that is extended with more

--- a/README.md
+++ b/README.md
@@ -443,9 +443,21 @@ True
 
 ```
 
-### Recursive schema
+### Recursive / nested schema
 
-There is no syntax to have a recursive schema. The best way to do it is to have a wrapper like this:
+You can use `voluptuous.Self` to define a nested schema:
+
+```pycon
+>>> from voluptuous import Schema, Self
+>>> recursive = Schema({"more": Self, "value": int})
+>>> recursive({"more": {"value": 42}, "value": 41}) == {'more': {'value': 42}, 'value': 41}
+True
+
+```
+
+This only works if `Self` is used in the `Schema` directly. If you use `Any`,
+`All` or `SomeOf`, this won't work as they compile their arguments down to a
+new `Schema`. In that case, you can use an external reference:
 
 ```pycon
 >>> from voluptuous import Schema, Any

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -276,6 +276,8 @@ class Schema(object):
             return lambda _, v: v
         if schema is Self:
             return lambda p, v: self._compiled(p, v)
+        elif hasattr(schema, "__voluptuous_compile__"):
+            return schema.__voluptuous_compile__(self)
         if isinstance(schema, Object):
             return self._compile_object(schema)
         if isinstance(schema, collections.Mapping):

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -122,6 +122,10 @@ class Undefined(object):
 UNDEFINED = Undefined()
 
 
+def Self():
+    raise er.SchemaError('"Self" should never be called')
+
+
 def default_factory(value):
     if value is UNDEFINED or callable(value):
         return value
@@ -270,6 +274,8 @@ class Schema(object):
     def _compile(self, schema):
         if schema is Extra:
             return lambda _, v: v
+        if schema is Self:
+            return lambda p, v: self._compiled(p, v)
         if isinstance(schema, Object):
             return self._compile_object(schema)
         if isinstance(schema, collections.Mapping):

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1085,6 +1085,55 @@ def test_self_validation():
     schema({"follow": {"follow": {"number": 123456}}})
 
 
+def test_self_any():
+    schema = Schema({"number": int,
+                     "follow": Any(Self, "stop")})
+    try:
+        schema({"number": "abc"})
+    except MultipleInvalid:
+        pass
+    else:
+        assert False, "Did not raise Invalid"
+    try:
+        schema({"follow": {"number": '123456.712'}})
+    except MultipleInvalid:
+        pass
+    else:
+        assert False, "Did not raise Invalid"
+    schema({"follow": {"number": 123456}})
+    schema({"follow": {"follow": {"number": 123456}}})
+    schema({"follow": {"follow": {"number": 123456, "follow": "stop"}}})
+
+
+def test_self_all():
+    schema = Schema({"number": int,
+                     "follow": All(Self,
+                                   Schema({"extra_number": int},
+                                          extra=ALLOW_EXTRA))},
+                    extra=ALLOW_EXTRA)
+    try:
+        schema({"number": "abc"})
+    except MultipleInvalid:
+        pass
+    else:
+        assert False, "Did not raise Invalid"
+    try:
+        schema({"follow": {"number": '123456.712'}})
+    except MultipleInvalid:
+        pass
+    else:
+        assert False, "Did not raise Invalid"
+    schema({"follow": {"number": 123456}})
+    schema({"follow": {"follow": {"number": 123456}}})
+    schema({"follow": {"number": 123456, "extra_number": 123}})
+    try:
+        schema({"follow": {"number": 123456, "extra_number": "123"}})
+    except MultipleInvalid:
+        pass
+    else:
+        assert False, "Did not raise Invalid"
+
+
 def test_SomeOf_on_bounds_assertion():
     with raises(AssertionError, 'when using "SomeOf" you should specify at least one of min_valid and max_valid'):
         SomeOf(validators=[])

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -10,7 +10,8 @@ from voluptuous import (
     Url, MultipleInvalid, LiteralInvalid, TypeInvalid, NotIn, Match, Email,
     Replace, Range, Coerce, All, Any, Length, FqdnUrl, ALLOW_EXTRA, PREVENT_EXTRA,
     validate, ExactSequence, Equal, Unordered, Number, Maybe, Datetime, Date,
-    Contains, Marker, IsDir, IsFile, PathExists, SomeOf, TooManyValid, raises)
+    Contains, Marker, IsDir, IsFile, PathExists, SomeOf, TooManyValid, Self,
+    raises)
 from voluptuous.humanize import humanize_error
 from voluptuous.util import u
 
@@ -1063,6 +1064,25 @@ def test_SomeOf_max_validation():
     validator('Aa')
     with raises(TooManyValid, 'max validation test failed'):
         validator('Aa1')
+
+
+def test_self_validation():
+    schema = Schema({"number": int,
+                     "follow": Self})
+    try:
+        schema({"number": "abc"})
+    except MultipleInvalid:
+        pass
+    else:
+        assert False, "Did not raise Invalid"
+    try:
+        schema({"follow": {"number": '123456.712'}})
+    except MultipleInvalid:
+        pass
+    else:
+        assert False, "Did not raise Invalid"
+    schema({"follow": {"number": 123456}})
+    schema({"follow": {"follow": {"number": 123456}}})
 
 
 def test_SomeOf_on_bounds_assertion():


### PR DESCRIPTION
This PR is made of 2 commits:

- _Allow to use nested schema_ that adds `voluptuous.Self` as a reference to the `Schema` being compiled.

- _Allow any validator to be compiled_ which allows to compile validators and implements that compilation on validators with subvalidators (and/or/someof) in order to avoid the sub`Schema` creation. This solves the recursive `voluptuous.Self` case elegantly.

Hope you'll enjoy it!
