### PR TITLE
Added validation for default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## [Unreleased]
 
 - [#280](https://github.com/alecthomas/voluptuous/pull/280): Making
-`IsDir()`, `IsFile()` and `PathExists()` consistent between different python versions.
+  `IsDir()`, `IsFile()` and `PathExists()` consistent between different python versions.
 - [#279](https://github.com/alecthomas/voluptuous/pull/279):
   Treat Python 2 old-style classes like types when validating.
+- [324](https://github.com/alecthomas/voluptuous/pull/324):
+  Default values MUST now pass validation just as any regular value.
 
 ## [0.10.5]
 


### PR DESCRIPTION
Hi,

This PR adds validation for default values as discussed with @alecthomas in https://github.com/alecthomas/voluptuous/issues/264.

I tested the changes locally and got the expected behaviour so far, unittests passed as well.

It has to be mentioned that this breaks backwards compatibility if one used default values before which would now fail validation, but doing so should be considered as bad practice IMHO anyway. So this change should encourage to not insert default values that violate ones own schema.

Best regards
Robert
