### PR TITLE
Add Schema.remove method to remove keys from dict (opposite of extend).

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -733,6 +733,14 @@ class Schema(object):
         result_extra = (extra if extra is not None else self.extra)
         return Schema(result, required=result_required, extra=result_extra)
 
+    def remove(self, schema):
+        """Return Schema without keys in `schema`.
+        
+        Opposite of extend."""
+        removal = {Remove(key): types
+                   for key, types in schema.items()}
+        return self.extend(removal)
+
 
 def _compile_scalar(schema):
     """A scalar value.

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -399,6 +399,30 @@ def test_schema_extend_key_swap():
     assert_true((list(extended.schema)[0], Required))
 
 
+def test_remove_method():
+    """Test removal of keys from schema (inverse extend)."""
+
+    article = Schema({Required('art_no'): int,
+                      Required('colour'): str,
+                      Required('size'): int})
+
+    ext = {Required('qty'): int,
+           Required('price'): float}
+
+    pos = article.extend(ext)
+
+    pos1 = {'art_no': 999,
+            'colour': 'green',
+            'size': 20,
+            'qty': 15,
+            'price': 20.9}
+
+    article_from_pos = pos.remove(ext)
+
+    for key in ['price', 'qty']:
+        assert key not in article_from_pos.schema.keys()
+
+
 def test_subschema_extension():
     """Verify that Schema.extend adds and replaces keys in a subschema"""
 


### PR DESCRIPTION
If there is `extend` method, why not go the other way around?