### PR TITLE
Modified __lt__ in Marker class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   Treat Python 2 old-style classes like types when validating.
 - [324](https://github.com/alecthomas/voluptuous/pull/324):
   Default values MUST now pass validation just as any regular value. This is a backward incompatible change if a schema uses default values that don't pass validation against the specified schema.
+- [328](https://github.com/alecthomas/voluptuous/pull/328):
+  Modified __lt__ in Marker class to allow comparison with non Marker objects, such as str and int
 
 ## [0.10.5]
 

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -953,7 +953,9 @@ class Marker(object):
         return repr(self.schema)
 
     def __lt__(self, other):
-        return self.schema < other.schema
+        if isinstance(other, Marker):
+            return self.schema < other.schema
+        return self.schema < other
 
     def __hash__(self):
         return hash(self.schema)

--- a/voluptuous/tests/tests.md
+++ b/voluptuous/tests/tests.md
@@ -266,3 +266,8 @@ Ensure that subclasses of Invalid of are raised as is.
     ...   exc = e
     >>> exc.errors[0].__class__.__name__
     'SpecialInvalid'
+
+Ensure that Optional('Classification') < 'Name' will return True instead of throwing an AttributeError
+
+    >>> Optional('Classification') < 'Name'
+    True

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1137,3 +1137,7 @@ def test_self_all():
 def test_SomeOf_on_bounds_assertion():
     with raises(AssertionError, 'when using "SomeOf" you should specify at least one of min_valid and max_valid'):
         SomeOf(validators=[])
+
+
+def test_comparing_voluptuous_object_to_str():
+    assert_true(Optional('Classification') < 'Name')


### PR DESCRIPTION
Marker class in `/voluptuous/schema_builder.py` needed to have the `__lt__()` function
modified in order to compare against regular strings as well.

This will allow the usage of Voluptuous Optional objects as keys in dicts alongside
strings and int.

An example of this would be a dict as such:

```Python
{
    'Name': <function is_str at 0x1057b8b90>,
    'ExecutionTimestamp': <function is_str at 0x1057b8b90>,
    Optional('Classification'): [Any([<function is_str at 0x1057b8b90>, <function is_null at 0x1057b8aa0>])]
}
```

Sorting the above dict without the proposed changes will result in an error similar to the one below:
```
  File "/Users/mo2000/Work/QA/venv/lib/python2.7/site-packages/voluptuous/schema_builder.py", line 902, in __lt__
    return self.schema < other.schema
```