### PR TITLE
Updated changelog to include changes merged after 0.10.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,34 @@
 
 ## [Unreleased]
 
-- [#280](https://github.com/alecthomas/voluptuous/pull/280): Making
-  `IsDir()`, `IsFile()` and `PathExists()` consistent between different python versions.
+**Changes**:
+
+- [#293](https://github.com/alecthomas/voluptuous/pull/293): Support Python 3.6.
+- [#294](https://github.com/alecthomas/voluptuous/pull/294): Drop support for Python 2.6, 3.1 and 3.2.
+- [#318](https://github.com/alecthomas/voluptuous/pull/318): Allow to use nested schema and allow any validator to be compiled.
+- [#324](https://github.com/alecthomas/voluptuous/pull/324):
+  Default values MUST now pass validation just as any regular value. This is a backward incompatible change if a schema uses default values that don't pass validation against the specified schema.
+- [#328](https://github.com/alecthomas/voluptuous/pull/328):
+  Modify `__lt__` in Marker class to allow comparison with non Marker objects, such as str and int.
+
+**New**:
+
+- [#307](https://github.com/alecthomas/voluptuous/pull/307): Add description field to `Marker` instances.
+- [#311](https://github.com/alecthomas/voluptuous/pull/311): Add `Schema.infer` method for basic schema inference.
+- [#314](https://github.com/alecthomas/voluptuous/pull/314): Add `SomeOf` validator.
+
+**Fixes**:
+
 - [#279](https://github.com/alecthomas/voluptuous/pull/279):
   Treat Python 2 old-style classes like types when validating.
-- [324](https://github.com/alecthomas/voluptuous/pull/324):
-  Default values MUST now pass validation just as any regular value. This is a backward incompatible change if a schema uses default values that don't pass validation against the specified schema.
-- [328](https://github.com/alecthomas/voluptuous/pull/328):
-  Modified __lt__ in Marker class to allow comparison with non Marker objects, such as str and int
+- [#280](https://github.com/alecthomas/voluptuous/pull/280): Make
+  `IsDir()`, `IsFile()` and `PathExists()` consistent between different Python versions.
+- [#290](https://github.com/alecthomas/voluptuous/pull/290): Use absolute imports to avoid import conflicts.
+- [#291](https://github.com/alecthomas/voluptuous/pull/291): Fix `Coerce` validator to catch `decimal.InvalidOperation`.
+- [#298](https://github.com/alecthomas/voluptuous/pull/298): Make `Schema([])` usage consistent with `Schema({})`.
+- [#303](https://github.com/alecthomas/voluptuous/pull/303): Allow partial validation when using validate decorator.
+- [#316](https://github.com/alecthomas/voluptuous/pull/316): Make `Schema.__eq__` deterministic.
+- [#319](https://github.com/alecthomas/voluptuous/pull/319): Replace implementation of `Maybe(s)` with `Any(None, s)` to allow it to be compiled.
 
 ## [0.10.5]
 


### PR DESCRIPTION
This pull request includes the changes made after the commit that bumps the project to 0.10.5.

I have tried to be consistent with the other changelog entries: sorted from low to high, same tense ("Add" vs "Added") and have divided the changes into changes / new / fixes as was done for 0.10.2.

Thanks for developing this library, maintaining it and checking these pull requests!