### PR TITLE
Don't stop to first error in a list of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+**Fixes**:
+
+- [#330](https://github.com/alecthomas/voluptuous/pull/330):
+  Don't stop validation to first error in a list of objects.
+
 ## [0.11.0]
 
 **Changes**:

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -630,8 +630,6 @@ class Schema(object):
                             out.append(cval)
                         break
                     except er.Invalid as e:
-                        if len(e.path) > len(index_path):
-                            raise
                         invalid = e
                 else:
                     errors.append(invalid)

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -515,6 +515,25 @@ def test_list_validation_messages():
         assert False, "Did not raise Invalid"
 
 
+def test_list_error_reporting():
+
+    schema = Schema([int])
+    try:
+        schema(['foo', 'bar'])
+    except MultipleInvalid as e:
+        assert len(e.errors) == 2
+    else:
+        assert False
+
+    schema = Schema([{'id': int}])
+    try:
+        schema([{'id': 'foo'}, {'id': 'bar'}])
+    except MultipleInvalid as e:
+        assert len(e.errors) == 2
+    else:
+        assert False
+
+
 def test_nested_multiple_validation_errors():
     """ Make sure useful error messages are available """
 


### PR DESCRIPTION
List of primitives iterates whole list and records every error, but list of objects doesn't.

The change is quite radical - I don't really understand what the removed block does, but removing it doesn't fail any tests. I think it's only in effect when validating a list of objects. But why was it originally added - why stop at first error and not validate all elements in a list?