### PR TITLE
Use direct link to changelog to make it work on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The documentation is provided [here](http://alecthomas.github.io/voluptuous/).
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md).
+See [CHANGELOG.md](https://github.com/alecthomas/voluptuous/blob/master/CHANGELOG.md).
 
 ## Show me an example
 


### PR DESCRIPTION
On https://pypi.org/project/voluptuous/ the link to `CHANGELOG.md` is pointing to https://pypi.org/project/voluptuous/CHANGELOG.md/.

This change fixes that.