### PR TITLE
Added support for sets and frozensets

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,59 @@ True
 
 ```
 
+### Sets and frozensets
+
+Sets and frozensets are treated as a set of valid values. Each element
+in the schema set is compared to each value in the input data:
+
+```pycon
+>>> schema = Schema({42})
+>>> schema({42}) == {42}
+True
+>>> try:
+...   schema({43})
+...   raise AssertionError('MultipleInvalid not raised')
+... except MultipleInvalid as e:
+...   exc = e
+>>> str(exc) == "invalid value in set"
+True
+>>> schema = Schema({int})
+>>> schema({1, 2, 3}) == {1, 2, 3}
+True
+>>> schema = Schema({int, str})
+>>> schema({1, 2, 'abc'}) == {1, 2, 'abc'}
+True
+>>> schema = Schema(frozenset([int]))
+>>> try:
+...   schema({3})
+...   raise AssertionError('Invalid not raised')
+... except Invalid as e:
+...   exc = e
+>>> str(exc) == 'expected a frozenset'
+True
+
+```
+
+However, an empty set (`set()`) is treated as is. If you want to specify a set
+that can contain anything, specify it as `set`:
+
+```pycon
+>>> schema = Schema(set())
+>>> try:
+...   schema({1})
+...   raise AssertionError('MultipleInvalid not raised')
+... except MultipleInvalid as e:
+...   exc = e
+>>> str(exc) == "invalid value in set"
+True
+>>> schema(set()) == set()
+True
+>>> schema = Schema(set)
+>>> schema({1, 2}) == {1, 2}
+True
+
+```
+
 ### Validation functions
 
 Validators are simple callables that raise an `Invalid` exception when

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1141,3 +1141,73 @@ def test_SomeOf_on_bounds_assertion():
 
 def test_comparing_voluptuous_object_to_str():
     assert_true(Optional('Classification') < 'Name')
+
+
+def test_set_of_integers():
+    schema = Schema({int})
+    with raises(Invalid, 'expected a set'):
+        schema(42)
+    with raises(Invalid, 'expected a set'):
+        schema(frozenset([42]))
+
+    schema(set())
+    schema(set([42]))
+    schema(set([42, 43, 44]))
+    try:
+        schema(set(['abc']))
+    except MultipleInvalid as e:
+        assert_equal(str(e), "invalid value in set")
+    else:
+        assert False, "Did not raise Invalid"
+
+
+def test_frozenset_of_integers():
+    schema = Schema(frozenset([int]))
+    with raises(Invalid, 'expected a frozenset'):
+        schema(42)
+    with raises(Invalid, 'expected a frozenset'):
+        schema(set([42]))
+
+    schema(frozenset())
+    schema(frozenset([42]))
+    schema(frozenset([42, 43, 44]))
+    try:
+        schema(frozenset(['abc']))
+    except MultipleInvalid as e:
+        assert_equal(str(e), "invalid value in frozenset")
+    else:
+        assert False, "Did not raise Invalid"
+
+
+def test_set_of_integers_and_strings():
+    schema = Schema({int, str})
+    with raises(Invalid, 'expected a set'):
+        schema(42)
+
+    schema(set())
+    schema(set([42]))
+    schema(set(['abc']))
+    schema(set([42, 'abc']))
+    try:
+        schema(set([None]))
+    except MultipleInvalid as e:
+        assert_equal(str(e), "invalid value in set")
+    else:
+        assert False, "Did not raise Invalid"
+
+
+def test_frozenset_of_integers_and_strings():
+    schema = Schema(frozenset([int, str]))
+    with raises(Invalid, 'expected a frozenset'):
+        schema(42)
+
+    schema(frozenset())
+    schema(frozenset([42]))
+    schema(frozenset(['abc']))
+    schema(frozenset([42, 'abc']))
+    try:
+        schema(frozenset([None]))
+    except MultipleInvalid as e:
+        assert_equal(str(e), "invalid value in frozenset")
+    else:
+        assert False, "Did not raise Invalid"


### PR DESCRIPTION
Hi there, this is a proposed fix for #292.

The docstring was done slightly differently than the others as the behaviour differs in the Python shell between Python 2.7 and Python 3.1+ (`set([42])`  vs `{42}`):

```pycon
>>> set([42])
set([42])
```

```pycon
>>> set([42])
{42}
```

The raised `Invalid` exceptions aren't used to avoid the problem that sequences currently have:

```python
Schema([int,str])([3.4])
```

results in `voluptuous.error.MultipleInvalid: expected str @ data[0]` (the error message can be considered true but also incomplete as `int` is also allowed).

I'm not sure how to solve this - this could perhaps be refined in a future pull request?