### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py33,py34,py35,py36
+envlist = flake8,py27,py34,py35,py36
 
 [flake8]
 ; E501: line too long (X > 79 characters)
@@ -26,9 +26,6 @@ commands = flake8 --doctests setup.py voluptuous
 
 [testenv:py27]
 basepython = python2.7
-
-[testenv:py33]
-basepython = python3.3
 
 [testenv:py34]
 basepython = python3.4


### PR DESCRIPTION
Python 3.3 has reached end-of-life: https://devguide.python.org/#status-of-python-branches (2017-09-29).