### PR TITLE
Avoid raising StopIteration in generator

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -856,7 +856,6 @@ def _iterate_object(obj):
         for key in slots:
             if key != '__dict__':
                 yield (key, getattr(obj, key))
-    raise StopIteration()
 
 
 class Msg(object):


### PR DESCRIPTION
Removing this line makes the tests pass again in Python 3.7.

This is due to the changes in PEP 479 (https://www.python.org/dev/peps/pep-0479/) which got released in Python 3.7 (https://bugs.python.org/issue32670).

Based on https://stackoverflow.com/questions/14183803/what-is-the-difference-between-raise-stopiteration-and-a-return-statement-in-gen I think it's safe to make this change also for Python 3.6 and earlier versions of Python.