### PR TITLE
fix validators.Date behaviour when a custom format is specified

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -861,8 +861,13 @@ def test_datetime():
 def test_date():
     schema = Schema({"date": Date()})
     schema({"date": "2016-10-24"})
-    assert_raises(MultipleInvalid, schema, {"date": "2016-10-2"})
     assert_raises(MultipleInvalid, schema, {"date": "2016-10-24Z"})
+
+
+def test_date_custom_format():
+    schema = Schema({"date": Date("%Y%m%d")})
+    schema({"date": "20161024"})
+    assert_raises(MultipleInvalid, schema, {"date": "2016-10-24"})
 
 
 def test_ordered_dict():

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -636,15 +636,10 @@ class Date(Datetime):
     """Validate that the value matches the date format."""
 
     DEFAULT_FORMAT = '%Y-%m-%d'
-    FORMAT_DESCRIPTION = 'yyyy-mm-dd'
 
     def __call__(self, v):
         try:
             datetime.datetime.strptime(v, self.format)
-            if len(v) != len(self.FORMAT_DESCRIPTION):
-                raise DateInvalid(
-                    self.msg or 'value has invalid length'
-                                ' expected length %d (%s)' % (len(self.FORMAT_DESCRIPTION), self.FORMAT_DESCRIPTION))
         except (TypeError, ValueError):
             raise DateInvalid(
                 self.msg or 'value does not match'


### PR DESCRIPTION
As a side effect of the fix, the validator now considers non-zero-padded days and months as valid. I hope this is fine.