### PR TITLE
Updated Inclusive to accept description as well

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -1121,8 +1121,9 @@ class Inclusive(Optional):
     True
     """
 
-    def __init__(self, schema, group_of_inclusion, msg=None):
-        super(Inclusive, self).__init__(schema, msg=msg)
+    def __init__(self, schema, group_of_inclusion, msg=None, description=None):
+        super(Inclusive, self).__init__(schema, msg=msg,
+                                        description=description)
         self.group_of_inclusion = group_of_inclusion
 
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -6,8 +6,8 @@ import sys
 from nose.tools import assert_equal, assert_false, assert_raises, assert_true
 
 from voluptuous import (
-    Schema, Required, Exclusive, Optional, Extra, Invalid, In, Remove, Literal,
-    Url, MultipleInvalid, LiteralInvalid, TypeInvalid, NotIn, Match, Email,
+    Schema, Required, Exclusive, Inclusive, Optional, Extra, Invalid, In, Remove,
+    Literal, Url, MultipleInvalid, LiteralInvalid, TypeInvalid, NotIn, Match, Email,
     Replace, Range, Coerce, All, Any, Length, FqdnUrl, ALLOW_EXTRA, PREVENT_EXTRA,
     validate, ExactSequence, Equal, Unordered, Number, Maybe, Datetime, Date,
     Contains, Marker, IsDir, IsFile, PathExists, SomeOf, TooManyValid, Self,
@@ -1034,6 +1034,9 @@ def test_description():
 
     exclusive = Exclusive('alpha', 'angles', description='Hello')
     assert exclusive.description == 'Hello'
+
+    inclusive = Inclusive('alpha', 'angles', description='Hello')
+    assert inclusive.description == 'Hello'
 
     required = Required('key', description='Hello')
     assert required.description == 'Hello'


### PR DESCRIPTION
This makes the implementation consistent with `Exclusive` which is also a subclass of `Optional` and which also accepts description.

I think this might've been missed in the past but it seems logical to accept `description` for both.

I noticed this after looking at the documentation mentioned in https://github.com/alecthomas/voluptuous/issues/363.