### PR TITLE
Allow a discrminant field in validators

### DIFF
--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -283,8 +283,8 @@ class Union(_WithSubValidators):
     >>> validate = Schema(Union({'type':'a', 'a_val':'1'},{'type':'b', 'b_val':'2'},
     ...                         discriminant=lambda val, alt: filter(
     ...                         lambda v : v['type'] == val['type'] , alt)))
-    >>> validate({'type':'a', 'a_val':'1'})
-    {'a_val': '1', 'type': 'a'}
+    >>> validate({'type':'a', 'a_val':'1'}) == {'type':'a', 'a_val':'1'}
+    True
     >>> with raises(MultipleInvalid, "not a valid value for dictionary value @ data['b_val']"):
     ...   validate({'type':'b', 'b_val':'5'})
 

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -283,10 +283,10 @@ class Union(_WithSubValidators):
     >>> validate = Schema(Union({'type':'a', 'a_val':'1'},{'type':'b', 'b_val':'2'},
     ...                         discriminant=lambda val, alt: filter(
     ...                         lambda v : v['type'] == val['type'] , alt)))
-    >>> validate({'type':'a', 'val':'1'})
-    True
+    >>> validate({'type':'a', 'a_val':'1'})
+    {'a_val': '1', 'type': 'a'}
     >>> with raises(MultipleInvalid, "not a valid value for dictionary value @ data['b_val']"):
-    ...   validate({'type':'b', 'a_val':'5'})
+    ...   validate({'type':'b', 'b_val':'5'})
 
     ```discriminant({'type':'b', 'a_val':'5'}, [{'type':'a', 'a_val':'1'},{'type':'b', 'b_val':'2'}])``` is invoked
 

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -274,11 +274,9 @@ class Union(_WithSubValidators):
     """Use the first validated value among those selected by discrminant.
 
     :param msg: Message to deliver to user if validation fails.
-    :param discriminant: Function to filter the values
+    :param discriminant(value, validators): Returns the filtered list of validators based on the value
     :param kwargs: All other keyword arguments are passed to the sub-Schema constructors.
     :returns: Return value of the first validator that passes.
-
-    discriminant(value, validators) is invoked in execution.
 
     >>> validate = Schema(Union({'type':'a', 'a_val':'1'},{'type':'b', 'b_val':'2'},
     ...                         discriminant=lambda val, alt: filter(


### PR DESCRIPTION
Attempts to fix #360 
The accepted solution was to add a `Union` type which requires a discriminant. What I have done is check for a `discrminant` argument, and run the `value` and alternatives through the discriminant function to obtain a filtered list of alternatives. This allows a discriminant field to be included in the existing types

Since the validators are compiled before execution, when using the `_WithSubValidators`  class, and the `value` is available during execution I cannot check if it is accepted by the discriminant or not any earlier than execution. In such a case I'd have to recompile the validators obtained from the discriminant.

I have a bunch of `print` statements committed which I will remove once this is approved.