### PR TITLE
Ignore .pytest_cache in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv
 docs/_build
 .vscode/
 .venv
+.pytest_cache


### PR DESCRIPTION
Allow anyone using py.test to have the pytest cache ignored. I noticed this when working on https://github.com/alecthomas/voluptuous/pull/371.