### PR TITLE
Added htmlcov directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs/_build
 .vscode/
 .venv
 .pytest_cache
+htmlcov


### PR DESCRIPTION
This directory should be ignored in case pytest-cov is used.

`py.test voluptuous/tests/tests.py --cov voluptuous --cov-report html`