### PR TITLE
Preserve Unicode strings when passed to utility functions

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -13,7 +13,7 @@ from voluptuous import (
     Contains, Marker, IsDir, IsFile, PathExists, SomeOf, TooManyValid, Self,
     raises)
 from voluptuous.humanize import humanize_error
-from voluptuous.util import u
+from voluptuous.util import u, Capitalize, Lower, Strip, Title, Upper
 
 
 def test_exact_sequence():
@@ -1272,3 +1272,38 @@ def test_frozenset_of_integers_and_strings():
         assert_equal(str(e), "invalid value in frozenset")
     else:
         assert False, "Did not raise Invalid"
+
+
+def test_lower_util_handles_various_inputs():
+    assert Lower(3) == "3"
+    assert Lower(u"3") == u"3"
+    assert Lower(b'\xe2\x98\x83'.decode("UTF-8")) == b'\xe2\x98\x83'.decode("UTF-8")
+    assert Lower(u"A") == u"a"
+
+
+def test_upper_util_handles_various_inputs():
+    assert Upper(3) == "3"
+    assert Upper(u"3") == u"3"
+    assert Upper(b'\xe2\x98\x83'.decode("UTF-8")) == b'\xe2\x98\x83'.decode("UTF-8")
+    assert Upper(u"a") == u"A"
+
+
+def test_capitalize_util_handles_various_inputs():
+    assert Capitalize(3) == "3"
+    assert Capitalize(u"3") == u"3"
+    assert Capitalize(b'\xe2\x98\x83'.decode("UTF-8")) == b'\xe2\x98\x83'.decode("UTF-8")
+    assert Capitalize(u"aaa aaa") == u"Aaa aaa"
+
+
+def test_title_util_handles_various_inputs():
+    assert Title(3) == "3"
+    assert Title(u"3") == u"3"
+    assert Title(b'\xe2\x98\x83'.decode("UTF-8")) == b'\xe2\x98\x83'.decode("UTF-8")
+    assert Title(u"aaa aaa") == u"Aaa Aaa"
+
+
+def test_strip_util_handles_various_inputs():
+    assert Strip(3) == "3"
+    assert Strip(u"3") == u"3"
+    assert Strip(b'\xe2\x98\x83'.decode("UTF-8")) == b'\xe2\x98\x83'.decode("UTF-8")
+    assert Strip(u" aaa ") == u"aaa"

--- a/voluptuous/util.py
+++ b/voluptuous/util.py
@@ -7,6 +7,14 @@ from voluptuous import validators
 __author__ = 'tusharmakkar08'
 
 
+def _fix_str(v):
+    if sys.version_info[0] == 2 and isinstance(v, unicode):
+        s = v
+    else:
+        s = str(v)
+    return s
+
+
 def Lower(v):
     """Transform a string to lower case.
 
@@ -14,7 +22,7 @@ def Lower(v):
     >>> s('HI')
     'hi'
     """
-    return str(v).lower()
+    return _fix_str(v).lower()
 
 
 def Upper(v):
@@ -24,7 +32,7 @@ def Upper(v):
     >>> s('hi')
     'HI'
     """
-    return str(v).upper()
+    return _fix_str(v).upper()
 
 
 def Capitalize(v):
@@ -34,7 +42,7 @@ def Capitalize(v):
     >>> s('hello world')
     'Hello world'
     """
-    return str(v).capitalize()
+    return _fix_str(v).capitalize()
 
 
 def Title(v):
@@ -44,7 +52,7 @@ def Title(v):
     >>> s('hello world')
     'Hello World'
     """
-    return str(v).title()
+    return _fix_str(v).title()
 
 
 def Strip(v):
@@ -54,7 +62,7 @@ def Strip(v):
     >>> s('  hello world  ')
     'hello world'
     """
-    return str(v).strip()
+    return _fix_str(v).strip()
 
 
 class DefaultTo(object):


### PR DESCRIPTION
First of all, best wishes for 2019.

This updates the string utility functions to return a Unicode string when a Unicode string is passed in. In Python 2 this would raise an error due to the use of str(v).

This is a change related to issue #374.

The tests also check for other types (int) to preserve existing functionality.