### PR TITLE
Fix datetime namespace typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ validator:
 ```pycon
 >>> schema = Schema(Date())
 >>> schema('2013-03-03')
-datetime.datetime(2013, 3, 3, 0, 0)
+datetime(2013, 3, 3, 0, 0)
 >>> try:
 ...   schema('2013-03')
 ...   raise AssertionError('MultipleInvalid not raised')


### PR DESCRIPTION
Fixes module usage typo.
Readme example imported  `from datetime import datetime` and attempted to use `datetime.datetime(2013, 3, 3, 0, 0)` which resulted in: 
```
AttributeError: type object 'datetime.datetime' has no attribute 'datetime'
```
Changed to `datetime(2013, 3, 3, 0, 0)`

