### PR TITLE
Added additional tests for Range, Clamp and Length + catch exceptions

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -593,14 +593,15 @@ def test_range_inside():
 def test_range_outside():
     s = Schema(Range(min=0, max=10))
     assert_raises(MultipleInvalid, s, 12)
+    assert_raises(MultipleInvalid, s, -1)
 
 
-def test_range_no_Upper():
+def test_range_no_upper_limit():
     s = Schema(Range(min=0))
     assert_true(123, s(123))
 
 
-def test_range_exlcudes_nan():
+def test_range_excludes_nan():
     s = Schema(Range(min=0, max=10))
     assert_raises(MultipleInvalid, s, float('nan'))
 
@@ -638,9 +639,13 @@ def test_clamp_below():
     assert_true(1, s(-3)) 
 
 
-def test_clamp_excludes_string():
+def test_clamp_invalid():
     s = Schema(Clamp(min=1, max=10))
-    assert_raises(MultipleInvalid, s, "abc")
+    if sys.version_info.major >= 3:
+        assert_raises(MultipleInvalid, s, None)
+        assert_raises(MultipleInvalid, s, "abc")
+    else:
+        assert_true(s(None))
 
 
 def test_length_ok():

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -587,7 +587,7 @@ def test_fix_157():
 
 def test_range_inside():
     s = Schema(Range(min=0, max=10))
-    assert_true(5, s(5))
+    assert_equal(5, s(5))
 
 
 def test_range_outside():
@@ -598,7 +598,7 @@ def test_range_outside():
 
 def test_range_no_upper_limit():
     s = Schema(Range(min=0))
-    assert_true(123, s(123))
+    assert_equal(123, s(123))
 
 
 def test_range_excludes_nan():
@@ -626,17 +626,17 @@ def test_range_excludes_unordered_object():
 
 def test_clamp_inside():
     s = Schema(Clamp(min=1, max=10))
-    assert_true(5, s(5))
+    assert_equal(5, s(5))
 
 
 def test_clamp_above():
     s = Schema(Clamp(min=1, max=10))
-    assert_true(10, s(12))   
+    assert_equal(10, s(12))   
 
 
 def test_clamp_below():
     s = Schema(Clamp(min=1, max=10))
-    assert_true(1, s(-3)) 
+    assert_equal(1, s(-3)) 
 
 
 def test_clamp_invalid():
@@ -645,15 +645,15 @@ def test_clamp_invalid():
         assert_raises(MultipleInvalid, s, None)
         assert_raises(MultipleInvalid, s, "abc")
     else:
-        assert_true(s(None))
+        assert_equal(1, s(None))
 
 
 def test_length_ok():
     v1 = ['a', 'b', 'c']
     s = Schema(Length(min=1, max=10))
-    assert_true(3, s(v1))
+    assert_equal(v1, s(v1))
     v2 = "abcde"
-    assert_true(5, s(v2))
+    assert_equal(v2, s(v2))
 
 
 def test_length_too_short():

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -607,10 +607,10 @@ class Range(object):
 
             return v
 
-        # Objects that lack a partial ordering, e.g. None will raise TypeError
+        # Objects that lack a partial ordering, e.g. None or strings will raise TypeError
         except TypeError:
             raise RangeInvalid(
-                self.msg or 'value must have a partial ordering')
+                self.msg or 'invalid value or type (must have a partial ordering)')
 
     def __repr__(self):
         return ('Range(min=%r, max=%r, min_included=%r,'
@@ -640,11 +640,17 @@ class Clamp(object):
         self.msg = msg
 
     def __call__(self, v):
-        if self.min is not None and v < self.min:
-            v = self.min
-        if self.max is not None and v > self.max:
-            v = self.max
-        return v
+        try:
+            if self.min is not None and v < self.min:
+                v = self.min
+            if self.max is not None and v > self.max:
+                v = self.max
+            return v
+
+        # Objects that lack a partial ordering, e.g. None or strings will raise TypeError
+        except TypeError:
+            raise RangeInvalid(
+                self.msg or 'invalid value or type (must have a partial ordering)')    
 
     def __repr__(self):
         return 'Clamp(min=%s, max=%s)' % (self.min, self.max)
@@ -659,13 +665,19 @@ class Length(object):
         self.msg = msg
 
     def __call__(self, v):
-        if self.min is not None and len(v) < self.min:
-            raise LengthInvalid(
-                self.msg or 'length of value must be at least %s' % self.min)
-        if self.max is not None and len(v) > self.max:
-            raise LengthInvalid(
-                self.msg or 'length of value must be at most %s' % self.max)
-        return v
+        try:
+            if self.min is not None and len(v) < self.min:
+                raise LengthInvalid(
+                    self.msg or 'length of value must be at least %s' % self.min)
+            if self.max is not None and len(v) > self.max:
+                raise LengthInvalid(
+                    self.msg or 'length of value must be at most %s' % self.max)
+            return v
+
+        # Objects that havbe no length e.g. None or strings will raise TypeError
+        except TypeError:
+            raise RangeInvalid(
+                self.msg or 'invalid value or type')    
 
     def __repr__(self):
         return 'Length(min=%s, max=%s)' % (self.min, self.max)


### PR DESCRIPTION
This previous PR https://github.com/alecthomas/voluptuous/pull/414 added support to catch invalid values/types for `Range`. I now added that also for `Clamp` and `Length`.

Additional I added some more tests to increase the coverage and verify the new exception handling for `Clamp` and `Length`.

It would be great if after merging, a new version 0.11.8 could be created, so that depending projects (such as home-assistant where I came across those type exceptions in the first place) can easily pull in those fixes.