### PR TITLE
Cleanup python versions (remove unsupported + add 3.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - '2.7'
 - '3.6'
 - '3.7'
-- pypy3.5
+- '3.8'
 install:
 - pip install coveralls
 - pip install 'coverage<4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 - '3.8'
 install:
 - pip install coveralls
-- pip install 'coverage<4'
+- pip install coverage
 script: nosetests --with-coverage --cover-package=voluptuous
 after_success:
 - coveralls

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ from setuptools import setup
 
 import sys
 import io
-import os
-import atexit
 sys.path.insert(0, '.')
 version = __import__('voluptuous').__version__
 
@@ -36,5 +34,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py34,py35,py36,py37
+envlist = flake8,py27,py36,py37,py38
 
 [flake8]
 ; E501: line too long (X > 79 characters)
@@ -23,18 +23,3 @@ commands =
 [testenv:flake8]
 deps = flake8
 commands = flake8 --doctests setup.py voluptuous
-
-[testenv:py27]
-basepython = python2.7
-
-[testenv:py34]
-basepython = python3.4
-
-[testenv:py35]
-basepython = python3.5
-
-[testenv:py36]
-basepython = python3.6
-
-[testenv:py37]
-basepython = python3.7


### PR DESCRIPTION
Python 3.4 and 3.5 have reached their end of support period.