### PR TITLE
Remove value enumeration when validating empty list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
         --with-coverage3 \
             --cover3-package=voluptuous \
             --cover3-branch \
-        --verbose
+        --verbose {posargs}
 
 [testenv:flake8]
 deps = flake8

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -615,11 +615,11 @@ class Schema(object):
             if not isinstance(data, seq_type):
                 raise er.SequenceTypeInvalid('expected a %s' % seq_type_name, path)
 
-            # Empty seq schema, allow any data.
+            # Empty seq schema, reject any data.
             if not schema:
                 if data:
                     raise er.MultipleInvalid([
-                        er.ValueInvalid('not a valid value', [value]) for value in data
+                        er.ValueInvalid('not a valid value', path if path else data)
                     ])
                 return data
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1528,3 +1528,17 @@ def test_any_with_discriminant():
         assert_equal(str(e), 'expected bool for dictionary value @ data[\'implementation\'][\'c-value\']')
     else:
         assert False, "Did not raise correct Invalid"
+
+
+def test_empty_list_raises_error_of_key_not_values():
+    """ https://github.com/alecthomas/voluptuous/issues/397 """
+    schema = Schema({
+        Required('variables', default=[]): []
+    })
+
+    try:
+        schema({'variables': ['x']})
+    except MultipleInvalid as e:
+        assert_equal(str(e), "not a valid value for dictionary value @ data['variables']")
+    else:
+        assert False, "Did not raise correct Invalid"


### PR DESCRIPTION
The behaviour seems to have been introduced in commit
95489bd443e9a654 that modified the schema of an empty list in order
to provide a consistent behaviour between Schema({}) and Schema([]).
    
The commit introduced an enumeration of the incorrect values rather
than the expected behaviour of showing the key with the incorrect
value.
    
This commit provides the expected behaviour, and is also consistent
with the 'pathless' behaviour currently implemented, meaning that
    
- Schema([])([1]) -> 'not a valid value @ data[1]'
- Schema({'key': []})({'key': [1]) -> 'not a valid dictionary value @ data['key'].
    
Finally, as new unit test is provided to ensure that the new behaviour
remains intact.
