### PR TITLE
Revert "Ensure `Maybe` propagates error information (#411)"

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -516,7 +516,7 @@ def test_repr():
     )
     assert_equal(repr(coerce_), "Coerce(int, msg='moo')")
     assert_equal(repr(all_), "All('10', Coerce(int, msg=None), msg='all msg')")
-    assert_equal(repr(maybe_int), "Any(%s, None, msg=None)" % str(int))
+    assert_equal(repr(maybe_int), "Any(None, %s, msg=None)" % str(int))
 
 
 def test_list_validation_messages():

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -747,7 +747,7 @@ def test_maybe_accepts_msg():
         assert s([])
 
 
-def test_maybe_returns_subvalidator_error():
+def test_maybe_returns_default_error():
     schema = Schema(Maybe(Range(1, 2)))
 
     # The following should be valid
@@ -759,7 +759,7 @@ def test_maybe_returns_subvalidator_error():
         # Should trigger a MultipleInvalid exception
         schema(3)
     except MultipleInvalid as e:
-        assert_equal(str(e), "value must be at most 2")
+        assert_equal(str(e), "not a valid value")
     else:
         assert False, "Did not raise correct Invalid"
 

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -555,7 +555,7 @@ def Maybe(validator, msg=None):
     ...  s("string")
 
     """
-    return Any(validator, None, msg=msg)
+    return Any(None, validator, msg=msg)
 
 
 class Range(object):


### PR DESCRIPTION
This reverts commit da3cc967f7b16f18bf8c1feacfeced8f10ce9e40.

See description in #439. I don't think this was intended to be a breaking change, but it will be for many consumers. The extra error information is _not_ worth breaking consumers.