### PR TITLE
Change email regex match to fullmatch

### DIFF
--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -435,7 +435,7 @@ def Email(v):
             raise EmailInvalid("Invalid email address")
         user_part, domain_part = v.rsplit('@', 1)
 
-        if not (USER_REGEX.match(user_part) and DOMAIN_REGEX.match(domain_part)):
+        if not (USER_REGEX.fullmatch(user_part) and DOMAIN_REGEX.fullmatch(domain_part)):
             raise EmailInvalid("Invalid email address")
         return v
     except:


### PR DESCRIPTION
This PR is about the current method used to conditionally match user and domain regex to email.
currently, it's using match which unwarrantedly accepts entries if domain has special characters after .com

it currently accepts, john@voluptuous.com> or john!@voluptuous.org!@($*!

thus, we need to fullmatch the domain or user to avoid such entries and validate them properly.