### PR TITLE
Ensure `sorted` in `In` works with container of data types

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -81,7 +81,7 @@ def test_in():
         assert False, "Did not raise InInvalid"
 
 
-def test_in_class():
+def test_in_data_type_container():
     """Verify that In works with container of data types."""
     schema = Schema({"type": In((int, str, float))})
     schema({"type": float})

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -81,6 +81,18 @@ def test_in():
         assert False, "Did not raise InInvalid"
 
 
+def test_in_class():
+    """Verify that In works with container of data types."""
+    schema = Schema({"type": In((int, str, float))})
+    schema({"type": float})
+    try:
+        schema({"type": 42})
+    except Invalid as e:
+        assert_equal(str(e), "value must be one of [<class 'float'>, <class 'int'>, <class 'str'>] for dictionary value @ data['type']")
+    else:
+        assert False, "Did not raise InInvalid"
+
+
 def test_not_in():
     """Verify that NotIn works."""
     schema = Schema({"color": NotIn(frozenset(["red", "blue", "yellow"]))})

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -88,7 +88,10 @@ def test_in_data_type_container():
     try:
         schema({"type": 42})
     except Invalid as e:
-        assert_equal(str(e), "value must be one of [<class 'float'>, <class 'int'>, <class 'str'>] for dictionary value @ data['type']")
+        if sys.version_info.major >= 3:
+            assert_equal(str(e), "value must be one of [<class 'float'>, <class 'int'>, <class 'str'>] for dictionary value @ data['type']")
+        else:
+            assert_equal(str(e), "value must be one of [<type 'float'>, <type 'int'>, <type 'str'>] for dictionary value @ data['type']")    
     else:
         assert False, "Did not raise InInvalid"
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -91,7 +91,7 @@ def test_in_data_type_container():
         if sys.version_info.major >= 3:
             assert_equal(str(e), "value must be one of [<class 'float'>, <class 'int'>, <class 'str'>] for dictionary value @ data['type']")
         else:
-            assert_equal(str(e), "value must be one of [<type 'float'>, <type 'int'>, <type 'str'>] for dictionary value @ data['type']")    
+            assert_equal(str(e), "value must be one of [<type 'float'>, <type 'int'>, <type 'str'>] for dictionary value @ data['type']")
     else:
         assert False, "Did not raise InInvalid"
 

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -752,7 +752,7 @@ class In(object):
             check = True
         if check:
             raise InInvalid(self.msg
-                            or 'value must be one of {}'.format(sorted(self.container)))
+                            or 'value must be one of {}'.format(sorted(self.container, key=str)))
         return v
 
     def __repr__(self):
@@ -773,7 +773,7 @@ class NotIn(object):
             check = True
         if check:
             raise NotInInvalid(self.msg
-                               or 'value must not be one of {}'.format(sorted(self.container)))
+                               or 'value must not be one of {}'.format(sorted(self.container, key=str)))
         return v
 
     def __repr__(self):


### PR DESCRIPTION
Alternative to https://github.com/alecthomas/voluptuous/pull/452

I would prefer to keep the sorting, since that IMHO improves the error message we return, especially when utilized in user facing use cases.

This PR nonetheless ensures we properly handle containers with data types.