### PR TITLE
Extend README to include coverage run commands + unpin `setupstools`

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,10 +715,15 @@ s({'password':'123', 'password_again': 1337})
 
 ## Running tests
 
-Voluptuous is using pytest:
+Voluptuous is using `pytest`:
 
-    $ pytest
+    pip install pytest
+    pytest
 
+To also include a coverage report:
+
+    pip install pytest pytest-cov coverage>=3.0
+    pytest --cov=voluptuous voluptuous/tests/
 
 ## Other libraries and inspirations
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ exclude = .tox,.venv,build,*.egg
 [testenv]
 distribute = True
 sitepackages = False
-setuptools_version = setuptools<58.0
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
Provided some more info on running the tests including a coverage report in the README.

Removed no longer required `setuptools` version pin (was needed with `nose` before).