### PR TITLE
Fix a few typos

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -866,7 +866,7 @@ def _compile_itemsort():
         for i, check_ in priority:
             if check_(key_):
                 return i
-        # values have hightest priorities
+        # values have highest priorities
         return 0
 
     return item_priority

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -115,7 +115,7 @@ def test_remove():
     # remove keys by type
     schema = Schema({"weight": float,
                      "amount": int,
-                     # remvove str keys with int values
+                     # remove str keys with int values
                      Remove(str): int,
                      # keep str keys with str values
                      str: str})
@@ -1647,7 +1647,7 @@ def test_object():
     pytest.raises(MultipleInvalid, s, 345)
 
 
-# Python 3.7 removed the trainling comma in repr() of BaseException
+# Python 3.7 removed the trailing comma in repr() of BaseException
 # https://bugs.python.org/issue30399
 if sys.version_info >= (3, 7):
     invalid_scalar_excp_repr = "ScalarInvalid('not a valid value')"

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -689,7 +689,7 @@ class Length(object):
                     self.msg or 'length of value must be at most %s' % self.max)
             return v
 
-        # Objects that havbe no length e.g. None or strings will raise TypeError
+        # Objects that have no length e.g. None or strings will raise TypeError
         except TypeError:
             raise RangeInvalid(
                 self.msg or 'invalid value or type')
@@ -845,7 +845,7 @@ class ExactSequence(object):
 class Unique(object):
     """Ensure an iterable does not contain duplicate items.
 
-    Only iterables convertable to a set are supported (native types and
+    Only iterables convertible to a set are supported (native types and
     objects with correct __eq__).
 
     JSON does not support set, so they need to be presented as arrays.


### PR DESCRIPTION
There are small typos in:
- voluptuous/schema_builder.py
- voluptuous/tests/tests.py
- voluptuous/validators.py

Fixes:
- Should read `trailing` rather than `trainling`.
- Should read `remove` rather than `remvove`.
- Should read `highest` rather than `hightest`.
- Should read `have` rather than `havbe`.
- Should read `convertible` rather than `convertable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md