### PR TITLE
Change to SPDX conform license string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',
-    license='BSD',
+    license='BSD-3-Clause',
     platforms=['any'],
     packages=['voluptuous'],
     author='Alec Thomas',


### PR DESCRIPTION
I suggest to change the license string in the package information to an [SPDX parsable license expression](https://spdx.org/licenses/).
This makes it easier for downstream users to get the license information directly from the package metadata.