### PR TITLE
fix: fix project description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ version = __import__('voluptuous').__version__
 
 with io.open('README.md', encoding='utf-8') as f:
     long_description = f.read()
-    description = long_description.splitlines()[0].strip()
+    description = "Voluptuous is a Python data validation library"
 
 
 setup(


### PR DESCRIPTION
Closes #474.
The description was lost in 0.12.0 due to the addition of `CONTRIBUTIONS ONLY` section in README.md: https://github.com/alecthomas/voluptuous/commit/095cda05255a636a88b0c6583ebfe9511659f9df