### PR TITLE
Allow error reporting on keys

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -416,11 +416,6 @@ class Schema(object):
 
                     break
                 else:
-                    # KSK: Added the first two lines on 29 May 2022
-                    # Without them, when a Invalid error is raised from a key,
-                    # the message from the error is ignored and the error is
-                    # reported as an unknown key.  With this error, the error is
-                    # reported as raised.
                     if error:
                         errors.append(error)
                     elif remove_key:

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -416,7 +416,14 @@ class Schema(object):
 
                     break
                 else:
-                    if remove_key:
+                    # KSK: Added the first two lines on 29 May 2022
+                    # Without them, when a Invalid error is raised from a key,
+                    # the message from the error is ignored and the error is
+                    # reported as an unknown key.  With this error, the error is
+                    # reported as raised.
+                    if error:
+                        errors.append(error)
+                    elif remove_key:
                         # remove key
                         continue
                     elif self.extra == ALLOW_EXTRA:

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -358,7 +358,6 @@ class Schema(object):
                     # key, insert it.
                     key_value_map[key.schema] = key.default()
 
-            error = None
             errors = []
             for key, value in key_value_map.items():
                 key_path = path + [key]
@@ -369,6 +368,7 @@ class Schema(object):
 
                 # compare each given key/value against all compiled key/values
                 # schema key, (compiled key, compiled value)
+                error = None
                 for skey, (ckey, cvalue) in relevant_candidates:
                     try:
                         new_key = ckey(key_path, key)

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1599,6 +1599,41 @@ def test_any_with_discriminant():
         assert False, "Did not raise correct Invalid"
 
 
+def test_key1():
+    def as_int(a):
+        return int(a)
+
+    schema = Schema({as_int: str})
+    try:
+        schema({
+            '1': 'one',
+            'two': '2',
+        })
+    except MultipleInvalid as e:
+        assert str(e) == "not a valid value @ data['two']"
+    else:
+        assert False, "Did not raise correct Invalid"
+
+
+def test_key2():
+    def as_int(a):
+        try:
+            return int(a)
+        except ValueError:
+            raise Invalid('expecting a number')
+
+    schema = Schema({as_int: str})
+    try:
+        schema({
+            '1': 'one',
+            'two': '2',
+        })
+    except MultipleInvalid as e:
+        assert str(e) == "expecting a number @ data['two']"
+    else:
+        assert False, "Did not raise correct Invalid"
+
+
 if Enum:
     def test_coerce_enum():
         """Test Coerce Enum"""

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1608,9 +1608,13 @@ def test_key1():
         schema({
             '1': 'one',
             'two': '2',
+            '3': 'three',
+            'four': '4',
         })
     except MultipleInvalid as e:
-        assert str(e) == "not a valid value @ data['two']"
+        assert len(e.errors) == 2
+        assert str(e.errors[0]) == "not a valid value @ data['two']"
+        assert str(e.errors[1]) == "not a valid value @ data['four']"
     else:
         assert False, "Did not raise correct Invalid"
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1631,9 +1631,13 @@ def test_key2():
         schema({
             '1': 'one',
             'two': '2',
+            '3': 'three',
+            'four': '4',
         })
     except MultipleInvalid as e:
-        assert str(e) == "expecting a number @ data['two']"
+        assert len(e.errors) == 2
+        assert str(e.errors[0]) == "expecting a number @ data['two']"
+        assert str(e.errors[1]) == "expecting a number @ data['four']"
     else:
         assert False, "Did not raise correct Invalid"
 


### PR DESCRIPTION
I tweaked the error reporting code in voluptuous/schema_builder.py so that validation errors on keys are reported with a message based on the exception raised rather than treated as an extra key.  With this change exceptions on keys are treated in the same was as exceptions on values.

Before the change, when an Invalid error is raised on a key, the specifics of the error raised are ignored and the problem was reported as an extra key.  This results in several problems.  First, the reported error can be misleading.  Second, the error could go unreported if the extra parameter is passed as REMOVE_EXTRA or ALLOW_EXTRA to Schema.

One example where this was problematic is a case where I was expecting the keys to be dates, and any invalid dates, such as February 30, should be reported as invalid dates, but instead were reported as an extra key, which is confusing.

Here is a short program that illustrates the problem:
```
import arrow
from voluptuous import Schema, Invalid, MultipleInvalid

def as_date(arg):
    return arrow.get(arg, 'D MMMM YYYY')

data = {
    "29 February 2020": "...",
    "29 February 2021": "...",
    "29 February 2022": "...",
    "29 February 2023": "...",
}

validate = Schema({as_date: str})

try:
    validate(data)
except MultipleInvalid as e:
    for error in e.errors:
        print(error)
```
