### PR TITLE
Fix type hints and enable mypy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         include:
           - { python-version: "3.10", session: "flake8" }
+          - { python-version: "3.10", session: "mypy" }
           - { python-version: "3.10", session: "py310" }
           - { python-version: "3.9",  session: "py39" }
           - { python-version: "3.8",  session: "py38" }

--- a/tox.ini
+++ b/tox.ini
@@ -24,5 +24,7 @@ deps = flake8
 commands = flake8 --doctests setup.py voluptuous
 
 [testenv:mypy]
-deps = mypy pytest
+deps =
+    mypy
+    pytest
 commands = mypy voluptuous

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,7 @@ commands =
 [testenv:flake8]
 deps = flake8
 commands = flake8 --doctests setup.py voluptuous
+
+[testenv:mypy]
+deps = mypy pytest
+commands = mypy voluptuous

--- a/voluptuous/error.py
+++ b/voluptuous/error.py
@@ -21,8 +21,8 @@ class Invalid(Error):
 
     def __init__(self, message: str, path: typing.Optional[typing.List[str]] = None, error_message: typing.Optional[str] = None, error_type: typing.Optional[str] = None) -> None:
         Error.__init__(self, message)
-        self.path_value = path or []
-        self.error_message_value = error_message or message
+        self._path = path or []
+        self._error_message = error_message or message
         self.error_type = error_type
 
     @property
@@ -31,11 +31,11 @@ class Invalid(Error):
 
     @property
     def path(self) -> typing.List[str]:
-        return self.path_value
+        return self._path
 
     @property
     def error_message(self) -> str:
-        return self.error_message_value
+        return self._error_message
 
     def __str__(self) -> str:
         path = ' @ data[%s]' % ']['.join(map(repr, self.path)) \
@@ -46,7 +46,7 @@ class Invalid(Error):
         return output + path
 
     def prepend(self, path: typing.List[str]) -> None:
-        self.path_value = path + self.path_value
+        self._path = path + self.path
 
 
 class MultipleInvalid(Invalid):

--- a/voluptuous/error.py
+++ b/voluptuous/error.py
@@ -21,13 +21,21 @@ class Invalid(Error):
 
     def __init__(self, message: str, path: typing.Optional[typing.List[str]] = None, error_message: typing.Optional[str] = None, error_type: typing.Optional[str] = None) -> None:
         Error.__init__(self, message)
-        self.path = path or []
-        self.error_message = error_message or message
+        self.path_value = path or []
+        self.error_message_value = error_message or message
         self.error_type = error_type
 
     @property
     def msg(self) -> str:
         return self.args[0]
+
+    @property
+    def path(self) -> typing.List[str]:
+        return self.path_value
+
+    @property
+    def error_message(self) -> str:
+        return self.error_message_value
 
     def __str__(self) -> str:
         path = ' @ data[%s]' % ']['.join(map(repr, self.path)) \
@@ -38,7 +46,7 @@ class Invalid(Error):
         return output + path
 
     def prepend(self, path: typing.List[str]) -> None:
-        self.path = path + self.path
+        self.path_value = path + self.path_value
 
 
 class MultipleInvalid(Invalid):

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -753,8 +753,7 @@ class Schema(object):
         :param extra: if set, overrides `extra` of this `Schema`
         """
 
-        assert type(self.schema) == dict and type(schema) == dict, 'Both schemas must be dictionary-based'
-        assert isinstance(self.schema, dict)
+        assert isinstance(self.schema, dict) and isinstance(schema, dict), 'Both schemas must be dictionary-based'
 
         result = self.schema.copy()
 
@@ -779,7 +778,7 @@ class Schema(object):
 
                 # if both are dictionaries, we need to extend recursively
                 # create the new extended sub schema, then remove the old key and add the new one
-                if type(result_value) == dict and type(value) == dict:
+                if isinstance(result_value, dict) and isinstance(value, dict):
                     new_value = Schema(result_value).extend(value).schema
                     del result[result_key]
                     result[key] = new_value

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -165,11 +165,11 @@ extra = Extra
 primitive_types = (bool, bytes, int, long, str, unicode, float, complex)
 
 Schemable = typing.Union[
-    Extra, 'Schema', 'Object',
+    'Schema', 'Object',
     _Mapping,
     list, tuple, frozenset, set,
     bool, bytes, int, long, str, unicode, float, complex,
-    type, object, dict, type(None), typing.Callable
+    type, object, dict, None, typing.Callable
 ]
 
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -167,7 +167,7 @@ def test_literal():
     except MultipleInvalid as e:
         assert str(e) == "{'b': 1} not match for {'a': 1}"
         assert len(e.errors) == 1
-        assert type(e.errors[0]) == LiteralInvalid
+        assert isinstance(e.errors[0], LiteralInvalid)
     else:
         assert False, "Did not raise Invalid"
 
@@ -184,7 +184,7 @@ def test_class():
     except MultipleInvalid as e:
         assert str(e) == "expected C1"
         assert len(e.errors) == 1
-        assert type(e.errors[0]) == TypeInvalid
+        assert isinstance(e.errors[0], TypeInvalid)
     else:
         assert False, "Did not raise Invalid"
 
@@ -200,7 +200,7 @@ def test_class():
     except MultipleInvalid as e:
         assert str(e) == "expected C2"
         assert len(e.errors) == 1
-        assert type(e.errors[0]) == TypeInvalid
+        assert isinstance(e.errors[0], TypeInvalid)
     else:
         assert False, "Did not raise Invalid"
 


### PR DESCRIPTION
Type hints are not very useful if they are not checked.

* Breaking change: `Invalid.path` and `Invalid.error_message` are no longer writable (properties). Because they are propertis in subclass `MultipleInvalid` and subclass can't override writable as read only.
* Fix definition of `Schemable`. `Extra` is not a type but `Callable` and `Callable` is already there. For `NoneType` just `None` should be used.
* Add mypy to run with tox.
* Fix flake8 warnings regarding using `isinstance` instead of direct comparison.