### PR TITLE
Fix: Fix type hint for Coerce type param

### DIFF
--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -102,7 +102,7 @@ class Coerce(object):
         ...   validate('foo')
     """
 
-    def __init__(self, type: type | typing.Callable, msg: typing.Optional[str] = None) -> None:
+    def __init__(self, type: typing.Union[type, typing.Callable], msg: typing.Optional[str] = None) -> None:
         self.type = type
         self.msg = msg
         self.type_name = type.__name__

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -102,7 +102,7 @@ class Coerce(object):
         ...   validate('foo')
     """
 
-    def __init__(self, type: type, msg: typing.Optional[str] = None) -> None:
+    def __init__(self, type: type | callable, msg: typing.Optional[str] = None) -> None:
         self.type = type
         self.msg = msg
         self.type_name = type.__name__

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -102,7 +102,7 @@ class Coerce(object):
         ...   validate('foo')
     """
 
-    def __init__(self, type: type | callable, msg: typing.Optional[str] = None) -> None:
+    def __init__(self, type: type | typing.Callable, msg: typing.Optional[str] = None) -> None:
         self.type = type
         self.msg = msg
         self.type_name = type.__name__


### PR DESCRIPTION
Coerce can accept a callable as type except if I'm wrong.