### PR TITLE
Drop duplicated type checks in Schema._compile

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -311,7 +311,7 @@ class Schema(object):
         type_ = type(schema)
         if inspect.isclass(schema):
             type_ = schema
-        if type_ in (*primitive_types, object, list, dict, type(None)) or callable(schema):
+        if type_ in (*primitive_types, object, type(None)) or callable(schema):
             return _compile_scalar(schema)
         raise er.SchemaError('unsupported schema data type %r' %
                              type(schema).__name__)


### PR DESCRIPTION
Schema._compile calls `isinstance` to check for `list` and `Mapping`, hence the check further down testing for `list` or `dict` can never be True.