### PR TITLE
fix: allow path to be a list of strings, integers or any other hashables

### DIFF
--- a/voluptuous/error.py
+++ b/voluptuous/error.py
@@ -19,7 +19,13 @@ class Invalid(Error):
 
     """
 
-    def __init__(self, message: str, path: typing.Optional[typing.List[str]] = None, error_message: typing.Optional[str] = None, error_type: typing.Optional[str] = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        path: typing.Optional[typing.List[typing.Union[str, int]]] = None,
+        error_message: typing.Optional[str] = None,
+        error_type: typing.Optional[str] = None
+    ) -> None:
         Error.__init__(self, message)
         self._path = path or []
         self._error_message = error_message or message
@@ -30,7 +36,7 @@ class Invalid(Error):
         return self.args[0]
 
     @property
-    def path(self) -> typing.List[str]:
+    def path(self) -> typing.List[typing.Union[str, int]]:
         return self._path
 
     @property
@@ -45,7 +51,7 @@ class Invalid(Error):
             output += ' for ' + self.error_type
         return output + path
 
-    def prepend(self, path: typing.List[str]) -> None:
+    def prepend(self, path: typing.List[typing.Union[str, int]]) -> None:
         self._path = path + self.path
 
 
@@ -61,7 +67,7 @@ class MultipleInvalid(Invalid):
         return self.errors[0].msg
 
     @property
-    def path(self) -> typing.List[str]:
+    def path(self) -> typing.List[typing.Union[str, int]]:
         return self.errors[0].path
 
     @property
@@ -74,7 +80,7 @@ class MultipleInvalid(Invalid):
     def __str__(self) -> str:
         return str(self.errors[0])
 
-    def prepend(self, path: typing.List[str]) -> None:
+    def prepend(self, path: typing.List[typing.Union[str, int]]) -> None:
         for error in self.errors:
             error.prepend(path)
 

--- a/voluptuous/error.py
+++ b/voluptuous/error.py
@@ -22,7 +22,7 @@ class Invalid(Error):
     def __init__(
         self,
         message: str,
-        path: typing.Optional[typing.List[typing.Union[str, int]]] = None,
+        path: typing.Optional[typing.List[typing.Hashable]] = None,
         error_message: typing.Optional[str] = None,
         error_type: typing.Optional[str] = None
     ) -> None:
@@ -36,7 +36,7 @@ class Invalid(Error):
         return self.args[0]
 
     @property
-    def path(self) -> typing.List[typing.Union[str, int]]:
+    def path(self) -> typing.List[typing.Hashable]:
         return self._path
 
     @property
@@ -51,7 +51,7 @@ class Invalid(Error):
             output += ' for ' + self.error_type
         return output + path
 
-    def prepend(self, path: typing.List[typing.Union[str, int]]) -> None:
+    def prepend(self, path: typing.List[typing.Hashable]) -> None:
         self._path = path + self.path
 
 
@@ -67,7 +67,7 @@ class MultipleInvalid(Invalid):
         return self.errors[0].msg
 
     @property
-    def path(self) -> typing.List[typing.Union[str, int]]:
+    def path(self) -> typing.List[typing.Hashable]:
         return self.errors[0].path
 
     @property
@@ -80,7 +80,7 @@ class MultipleInvalid(Invalid):
     def __str__(self) -> str:
         return str(self.errors[0])
 
-    def prepend(self, path: typing.List[typing.Union[str, int]]) -> None:
+    def prepend(self, path: typing.List[typing.Hashable]) -> None:
         for error in self.errors:
             error.prepend(path)
 

--- a/voluptuous/humanize.py
+++ b/voluptuous/humanize.py
@@ -7,10 +7,7 @@ import typing
 MAX_VALIDATION_ERROR_ITEM_LENGTH = 500
 
 
-IndexT = typing.TypeVar("IndexT")
-
-
-def _nested_getitem(data: typing.Dict[IndexT, typing.Any], path: typing.List[IndexT]) -> typing.Optional[typing.Any]:
+def _nested_getitem(data: typing.Any, path: typing.List[typing.Union[str, int]]) -> typing.Optional[typing.Any]:
     for item_index in path:
         try:
             data = data[item_index]

--- a/voluptuous/humanize.py
+++ b/voluptuous/humanize.py
@@ -7,7 +7,7 @@ import typing
 MAX_VALIDATION_ERROR_ITEM_LENGTH = 500
 
 
-def _nested_getitem(data: typing.Any, path: typing.List[typing.Union[str, int]]) -> typing.Optional[typing.Any]:
+def _nested_getitem(data: typing.Any, path: typing.List[typing.Hashable]) -> typing.Optional[typing.Any]:
     for item_index in path:
         try:
             data = data[item_index]

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1328,6 +1328,7 @@ def test_match_error_has_path():
     else:
         assert False, "Did not raise MatchInvalid"
 
+
 def test_path_with_string():
     """Most common dict use with strings as keys"""
     s = Schema({'string_key': int})
@@ -1335,6 +1336,7 @@ def test_path_with_string():
     with pytest.raises(MultipleInvalid) as ctx:
         s({'string_key': 'str'})
     assert ctx.value.errors[0].path == ['string_key']
+
 
 def test_path_with_list_index():
     """Position of the offending list index included in path as int"""
@@ -1344,6 +1346,7 @@ def test_path_with_list_index():
         s({'string_key': [123, 'should be int']})
     assert ctx.value.errors[0].path == ['string_key', 1]
 
+
 def test_path_with_tuple_index():
     """Position of the offending tuple index included in path as int"""
     s = Schema({'string_key': (int,)})
@@ -1351,6 +1354,7 @@ def test_path_with_tuple_index():
     with pytest.raises(MultipleInvalid) as ctx:
         s({'string_key': (123, 'should be int')})
     assert ctx.value.errors[0].path == ['string_key', 1]
+
 
 def test_path_with_integer_dict_key():
     """Not obvious case with dict having not strings, but integers as keys"""
@@ -1360,6 +1364,7 @@ def test_path_with_integer_dict_key():
         s({1337: 'should be int'})
     assert ctx.value.errors[0].path == [1337]
 
+
 def test_path_with_float_dict_key():
     """Not obvious case with dict having not strings, but floats as keys"""
     s = Schema({13.37: int})
@@ -1368,6 +1373,7 @@ def test_path_with_float_dict_key():
         s({13.37: 'should be int'})
     assert ctx.value.errors[0].path == [13.37]
 
+
 def test_path_with_tuple_dict_key():
     """Not obvious case with dict having not strings, but tuples as keys"""
     s = Schema({('fancy', 'key'): int})
@@ -1375,6 +1381,7 @@ def test_path_with_tuple_dict_key():
     with pytest.raises(MultipleInvalid) as ctx:
         s({('fancy', 'key'): 'should be int'})
     assert ctx.value.errors[0].path == [('fancy', 'key')]
+
 
 def test_path_with_arbitrary_hashable_dict_key():
     """Not obvious case with dict having not strings, but arbitrary hashable objects as keys"""

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1328,6 +1328,69 @@ def test_match_error_has_path():
     else:
         assert False, "Did not raise MatchInvalid"
 
+def test_path_with_string():
+    """Most common dict use with strings as keys"""
+    s = Schema({'string_key': int})
+
+    with pytest.raises(MultipleInvalid) as ctx:
+        s({'string_key': 'str'})
+    assert ctx.value.errors[0].path == ['string_key']
+
+def test_path_with_list_index():
+    """Position of the offending list index included in path as int"""
+    s = Schema({'string_key': [int]})
+
+    with pytest.raises(MultipleInvalid) as ctx:
+        s({'string_key': [123, 'should be int']})
+    assert ctx.value.errors[0].path == ['string_key', 1]
+
+def test_path_with_tuple_index():
+    """Position of the offending tuple index included in path as int"""
+    s = Schema({'string_key': (int,)})
+
+    with pytest.raises(MultipleInvalid) as ctx:
+        s({'string_key': (123, 'should be int')})
+    assert ctx.value.errors[0].path == ['string_key', 1]
+
+def test_path_with_integer_dict_key():
+    """Not obvious case with dict having not strings, but integers as keys"""
+    s = Schema({1337: int})
+
+    with pytest.raises(MultipleInvalid) as ctx:
+        s({1337: 'should be int'})
+    assert ctx.value.errors[0].path == [1337]
+
+def test_path_with_float_dict_key():
+    """Not obvious case with dict having not strings, but floats as keys"""
+    s = Schema({13.37: int})
+
+    with pytest.raises(MultipleInvalid) as ctx:
+        s({13.37: 'should be int'})
+    assert ctx.value.errors[0].path == [13.37]
+
+def test_path_with_tuple_dict_key():
+    """Not obvious case with dict having not strings, but tuples as keys"""
+    s = Schema({('fancy', 'key'): int})
+
+    with pytest.raises(MultipleInvalid) as ctx:
+        s({('fancy', 'key'): 'should be int'})
+    assert ctx.value.errors[0].path == [('fancy', 'key')]
+
+def test_path_with_arbitrary_hashable_dict_key():
+    """Not obvious case with dict having not strings, but arbitrary hashable objects as keys"""
+
+    class HashableObjectWhichWillBeKeyInDict:
+        def __hash__(self):
+            return 1337  # dummy hash, used only for illustration
+
+    s = Schema({HashableObjectWhichWillBeKeyInDict: [int]})
+
+    hashable_obj_provided_in_input = HashableObjectWhichWillBeKeyInDict()
+
+    with pytest.raises(MultipleInvalid) as ctx:
+        s({hashable_obj_provided_in_input: [0, 1, 'should be int']})
+    assert ctx.value.errors[0].path == [hashable_obj_provided_in_input, 2]
+
 
 def test_self_any():
     schema = Schema({"number": int,

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -224,7 +224,7 @@ class _WithSubValidators(object):
         schema.required = old_required
         return self._run
 
-    def _run(self, path: typing.List[str], value):
+    def _run(self, path: typing.List[typing.Union[str, int]], value):
         if self.discriminant is not None:
             self._compiled = [
                 self.schema._compile(v)
@@ -243,7 +243,7 @@ class _WithSubValidators(object):
             self.msg
         )
 
-    def _exec(self, funcs: typing.Iterable, v, path: typing.Optional[typing.List[str]] = None):
+    def _exec(self, funcs: typing.Iterable, v, path: typing.Optional[typing.List[typing.Union[str, int]]] = None):
         raise NotImplementedError()
 
 

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -224,7 +224,7 @@ class _WithSubValidators(object):
         schema.required = old_required
         return self._run
 
-    def _run(self, path: typing.List[typing.Union[str, int]], value):
+    def _run(self, path: typing.List[typing.Hashable], value):
         if self.discriminant is not None:
             self._compiled = [
                 self.schema._compile(v)
@@ -243,7 +243,7 @@ class _WithSubValidators(object):
             self.msg
         )
 
-    def _exec(self, funcs: typing.Iterable, v, path: typing.Optional[typing.List[typing.Union[str, int]]] = None):
+    def _exec(self, funcs: typing.Iterable, v, path: typing.Optional[typing.List[typing.Hashable]] = None):
         raise NotImplementedError()
 
 


### PR DESCRIPTION
This is to address an issue introduced in https://github.com/alecthomas/voluptuous/pull/475

As I understand, in this PR, @ds-cbo assumed that the path fragments could only be strings. However, it just occured to me that there is no reason to not allow:
- integers, as used in list indices
- actually, any hashable type that could be a dictionary key (~however as this is not my usecase and I doubt it's widely needed, I didn't try to introduce it here~ EDIT: after discussion I've used typing.Hashable in the last commit. In case Alec will decide that only strings and ints are sufficient, he can just skip the last commit.)

Just to confirm, I've checked the examples from the readme - it seems that they demonstrate exactly this - integers in path as list indices:

```python
> import voluptuous
> schema=voluptuous.Schema([[2,3],6])
> try:
>   schema([[6]])
> except Exception as exc:
>   exc1=exc

> exc1
MultipleInvalid([ScalarInvalid('not a valid value')])

> str(exc1)
'not a valid value @ data[0][0]'

> exc1.path
[0, 0]
```

Also, this seems to be the intention behind the comment here:
```
def _nested_getitem(data: typing.Any, path: typing.List[typing.Union[str, int]]) -> typing.Optional[typing.Any]:
    for item_index in path:
        try:
            data = data[item_index]
        except (KeyError, IndexError, TypeError):
            # The index is not present in the dictionary, list or other
            # indexable or data is not subscriptable
            return None
```