### PR TITLE
feat: add python 3.11 to github workflow tox matrix, remove 3.7 from tox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
         include:
           - { python-version: "3.10", session: "flake8" }
           - { python-version: "3.10", session: "mypy" }
+          - { python-version: "3.11", session: "py311" }
           - { python-version: "3.10", session: "py310" }
           - { python-version: "3.9",  session: "py39" }
           - { python-version: "3.8",  session: "py38" }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python-version: "3.10", session: "flake8" }
-          - { python-version: "3.10", session: "mypy" }
+          - { python-version: "3.11", session: "flake8" }
+          - { python-version: "3.11", session: "mypy" }
           - { python-version: "3.11", session: "py311" }
           - { python-version: "3.10", session: "py310" }
           - { python-version: "3.9",  session: "py39" }

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py37,py38,py39,py310
+envlist = flake8,py38,py39,py310,py311
 
 [flake8]
 ; E501: line too long (X > 79 characters)


### PR DESCRIPTION
also: run mypy and flake8 on python 3.11 instead of 3.10