### PR TITLE
Ignore styling-only commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Add linters configuration, reformat whole code (#503)
+c5189d2b6f9dfb3016f094561afcfb5584d143ad


### PR DESCRIPTION
As per discussion in https://github.com/alecthomas/voluptuous/pull/503#issuecomment-1857800717 this will cause the git history to "hide" the restyling commit in git blame / git annotate.

Demo: https://github.com/antoni-szych-rtbhouse/voluptuous/blame/master/voluptuous/humanize.py

![image](https://github.com/alecthomas/voluptuous/assets/84847001/a0cf07a2-73af-4453-b722-0f136cfc0729)
