### PR TITLE
Remove Maybe validator typing

### DIFF
--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -594,7 +594,7 @@ def PathExists(v):
         raise PathInvalid("Not a Path")
 
 
-def Maybe(validator: typing.Callable, msg: typing.Optional[str] = None):
+def Maybe(validator, msg: typing.Optional[str] = None):
     """Validate that the object matches given validator or is None.
 
     :raises Invalid: If the value does not match the given validator and is not


### PR DESCRIPTION
Ref https://github.com/home-assistant/core/pull/120450#issuecomment-2189661020

The `validator` type for `Maybe` shouldn't be limited to `Callable`.
In the end it is passed to `_WithSubValidators` through `validators` which is currently untyped.
https://github.com/alecthomas/voluptuous/blob/2232c0e556bc68343388fa8499bdbf13196a7514/voluptuous/validators.py#L218-L228

Removed the incorrect typing from `Maybe` for now.