### PR TITLE
Use typing.Container for In validator

### DIFF
--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -810,7 +810,7 @@ class In(object):
     """Validate that a value is in a collection."""
 
     def __init__(
-        self, container: typing.Iterable, msg: typing.Optional[str] = None
+        self, container: typing.Container, msg: typing.Optional[str] = None
     ) -> None:
         self.container = container
         self.msg = msg


### PR DESCRIPTION
`... in ...` only requires `__contains__`. The `In` validator should therefore use `Container` instead of `Iterable`.

Refs https://github.com/home-assistant/core/pull/120268
/CC @bdraco

https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes