### PR TITLE
Use TypeVar for Schema.schema type

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -162,8 +162,10 @@ Schemable = typing.Union[
 ]
 # fmt: on
 
+_SchemableT = typing.TypeVar("_SchemableT", bound=Schemable)
 
-class Schema(object):
+
+class Schema(typing.Generic[_SchemableT]):
     """A validation schema.
 
     The schema is a Python tree-like structure where nodes are pattern
@@ -192,7 +194,7 @@ class Schema(object):
     }
 
     def __init__(
-        self, schema: Schemable, required: bool = False, extra: int = PREVENT_EXTRA
+        self, schema: _SchemableT, required: bool = False, extra: int = PREVENT_EXTRA
     ) -> None:
         """Create a new Schema.
 
@@ -812,7 +814,7 @@ class Schema(object):
                 result[key] = value
 
         # recompile and send old object
-        result_cls = type(self)
+        result_cls = typing.cast("type[Schema[dict]]", type(self))
         result_required = required if required is not None else self.required
         result_extra = extra if extra is not None else self.extra
         return result_cls(result, required=result_required, extra=result_extra)


### PR DESCRIPTION
`Schemable` is great as a catch all case. However, the Union prevents further uses especially of the `schema` attribute.
E.g.
```py
schema = vol.Schema({"key": str})
schema.schema.items()  # should access the dict items used to create the schema
```

This PR changes the `schema` attribute type to a `TypeVar`. This allows for either implicit or explicit specialization by the user. It would fallback to `typing.Any` if type checkers can't infer the specialized type.

_That's still better than the current situation as that just always emits an error._
```py
error: Item "type" of "Schema | Object | Mapping[Any, Any] | list[Any] | tuple[Any, ...] |
    <12 more items> | None" has no attribute "__iter__" (not iterable)  [union-attr]
```

Refs https://github.com/home-assistant/core/pull/120268