### PR TITLE
Type schema attribute as Any

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -208,7 +208,7 @@ class Schema(object):
             - Any value other than the above defaults to
               :const:`~voluptuous.PREVENT_EXTRA`
         """
-        self.schema = schema
+        self.schema: typing.Any = schema
         self.required = required
         self.extra = int(extra)  # ensure the value is an integer
         self._compiled = self._compile(schema)
@@ -1034,7 +1034,7 @@ class Marker(object):
         msg: typing.Optional[str] = None,
         description: typing.Optional[str] = None,
     ) -> None:
-        self.schema = schema_
+        self.schema: typing.Any = schema_
         self._schema = Schema(schema_)
         self.msg = msg
         self.description = description


### PR DESCRIPTION
`Schemable` is great as parameter type. However, without a dedicated type annotation mypy will also use it as argument type for `Schema.schema` and `Marker.schema` which just creates unhelpful errors when used
```py
error: Unsupported right operand type for in ("Schema | Object | Mapping[Any, Any] |
    list[Any] | tuple[Any, ...] | <12 more items> | None")  [operator]
error: Item "Schema" of "Schema | Object | Mapping[Any, Any] | list[Any] | tuple[Any, ...] |
    <12 more items> | None" has no attribute "items"  [union-attr]
```

Typing it as `Any` will "disable" type checking when using the `schema` attribute, while still providing the type safety for the parameter type.

_An alternative would have been #520. However that comes with its own set of issues as now all `Schemas` are generic and need additional type annotations._

Refs https://github.com/home-assistant/core/pull/120268