### PR TITLE
Allow Generators for vol.In

### DIFF
--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -812,7 +812,9 @@ class In(object):
     """Validate that a value is in a collection."""
 
     def __init__(
-        self, container: typing.Container, msg: typing.Optional[str] = None
+        self,
+        container: typing.Container | typing.Iterable,
+        msg: typing.Optional[str] = None,
     ) -> None:
         self.container = container
         self.msg = msg


### PR DESCRIPTION
While the use of `Container` for `vol.In` is correct, it's incompatible with `Generator` even though the `... in ...` check works fine.

> For objects that don’t define [__contains__()](https://docs.python.org/3/reference/datamodel.html#object.__contains__), the membership test first tries iteration via [__iter__()](https://docs.python.org/3/reference/datamodel.html#object.__iter__)

Ref #518
https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes
https://docs.python.org/3/reference/datamodel.html#object.__contains__

/CC @farmio