### PR TITLE
Fix bug with Any validator and  REMOVE_EXTRA

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -366,7 +366,7 @@ class Schema(object):
                         out[key] = value
                     elif self.extra == REMOVE_EXTRA:
                         #  ignore the key so it's removed from output
-                        pass
+                        continue
                     elif error:
                         errors.append(error)
                     else:

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -364,11 +364,13 @@ class Schema(object):
                         continue
                     elif self.extra == ALLOW_EXTRA:
                         out[key] = value
+                    elif self.extra == REMOVE_EXTRA:
+                        #  ignore the key so it's removed from output
+                        pass
                     elif error:
                         errors.append(error)
-                    elif self.extra != REMOVE_EXTRA:
+                    else:
                         errors.append(er.Invalid('extra keys not allowed', key_path))
-                        # else REMOVE_EXTRA: ignore the key so it's removed from output
 
             # for any required keys left that weren't found and don't have defaults:
             for key in required_keys:

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1794,27 +1794,6 @@ def test_any_with_extra_none():
     assert str(ctx.value.errors[0]) == "not a valid value @ data['additional_key']"
 
 
-def test_error_reporting_on_keys():
-
-    def validate(arg: str) -> str:
-        if arg == "29 February 2021":
-            raise ValueError("not a leap year")
-        return "2020-02-29"
-
-    schema = Schema({validate: str})
-
-    with pytest.raises(MultipleInvalid) as ctx:
-        schema(
-            {
-                "29 February 2020": "...",
-                "29 February 2021": "...",
-            }
-        )
-
-    assert len(ctx.value.errors) == 1
-    assert str(ctx.value.errors[0]) == "not a valid value @ data['29 February 2021']"
-
-
 def test_coerce_enum():
     """Test Coerce Enum"""
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -8,7 +8,7 @@ from enum import Enum
 import pytest
 
 from voluptuous import (
-    ALLOW_EXTRA, PREVENT_EXTRA, All, AllInvalid, Any, Clamp, Coerce, Contains,
+    ALLOW_EXTRA, PREVENT_EXTRA, REMOVE_EXTRA, All, AllInvalid, Any, Clamp, Coerce, Contains,
     ContainsInvalid, Date, Datetime, Email, EmailInvalid, Equal, ExactSequence,
     Exclusive, Extra, FqdnUrl, In, Inclusive, InInvalid, Invalid, IsDir, IsFile, Length,
     Literal, LiteralInvalid, Marker, Match, MatchInvalid, Maybe, MultipleInvalid, NotIn,
@@ -1711,6 +1711,23 @@ def test_key3():
             "domain": str,
         },
         extra=ALLOW_EXTRA,
+    )
+    schema(
+        {
+            "name": "one",
+            "domain": "two",
+            "additional_key": "extra",
+        }
+    )
+
+
+def test_key4():
+    schema = Schema(
+        {
+            Any("name", "area"): str,
+            "domain": str,
+        },
+        extra=REMOVE_EXTRA,
     )
     schema(
         {

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1704,7 +1704,7 @@ def test_key2():
     assert str(ctx.value.errors[1]) == "expecting a number @ data['four']"
 
 
-def test_key3():
+def test_any_with_extra_allow():
     schema = Schema(
         {
             Any("name", "area"): str,
@@ -1721,7 +1721,7 @@ def test_key3():
     )
 
 
-def test_key4():
+def test_any_with_extra_remove():
     schema = Schema(
         {
             Any("name", "area"): str,
@@ -1736,6 +1736,45 @@ def test_key4():
             "additional_key": "extra",
         }
     )
+
+
+def test_any_with_extra_prevent():
+    schema = Schema(
+        {
+            Any("name", "area"): str,
+            "domain": str,
+        },
+        extra=PREVENT_EXTRA,
+    )
+    with pytest.raises(MultipleInvalid) as ctx:
+        schema(
+            {
+                "name": "one",
+                "domain": "two",
+                "additional_key": "extra",
+            }
+        )
+    assert len(ctx.value.errors) == 1
+    assert str(ctx.value.errors[0]) == "not a valid value @ data['additional_key']"
+
+
+def test_any_with_extra_none():
+    schema = Schema(
+        {
+            Any("name", "area"): str,
+            "domain": str,
+        },
+    )
+    with pytest.raises(MultipleInvalid) as ctx:
+        schema(
+            {
+                "name": "one",
+                "domain": "two",
+                "additional_key": "extra",
+            }
+        )
+    assert len(ctx.value.errors) == 1
+    assert str(ctx.value.errors[0]) == "not a valid value @ data['additional_key']"
 
 
 def test_coerce_enum():

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1712,13 +1712,18 @@ def test_any_with_extra_allow():
         },
         extra=ALLOW_EXTRA,
     )
-    schema(
+    result = schema(
         {
             "name": "one",
             "domain": "two",
             "additional_key": "extra",
         }
     )
+    assert result == {
+        "name": "one",
+        "domain": "two",
+        "additional_key": "extra",
+    }
 
 
 def test_any_with_extra_remove():
@@ -1729,13 +1734,17 @@ def test_any_with_extra_remove():
         },
         extra=REMOVE_EXTRA,
     )
-    schema(
+    result = schema(
         {
             "name": "one",
             "domain": "two",
             "additional_key": "extra",
         }
     )
+    assert result == {
+        "name": "one",
+        "domain": "two",
+    }
 
 
 def test_any_with_extra_prevent():

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1712,6 +1712,7 @@ def test_any_with_extra_allow():
         },
         extra=ALLOW_EXTRA,
     )
+
     result = schema(
         {
             "name": "one",
@@ -1719,6 +1720,7 @@ def test_any_with_extra_allow():
             "additional_key": "extra",
         }
     )
+
     assert result == {
         "name": "one",
         "domain": "two",
@@ -1734,6 +1736,7 @@ def test_any_with_extra_remove():
         },
         extra=REMOVE_EXTRA,
     )
+
     result = schema(
         {
             "name": "one",
@@ -1741,6 +1744,7 @@ def test_any_with_extra_remove():
             "additional_key": "extra",
         }
     )
+
     assert result == {
         "name": "one",
         "domain": "two",
@@ -1755,6 +1759,7 @@ def test_any_with_extra_prevent():
         },
         extra=PREVENT_EXTRA,
     )
+
     with pytest.raises(MultipleInvalid) as ctx:
         schema(
             {
@@ -1763,6 +1768,7 @@ def test_any_with_extra_prevent():
                 "additional_key": "extra",
             }
         )
+
     assert len(ctx.value.errors) == 1
     assert str(ctx.value.errors[0]) == "not a valid value @ data['additional_key']"
 
@@ -1774,6 +1780,7 @@ def test_any_with_extra_none():
             "domain": str,
         },
     )
+
     with pytest.raises(MultipleInvalid) as ctx:
         schema(
             {
@@ -1782,8 +1789,30 @@ def test_any_with_extra_none():
                 "additional_key": "extra",
             }
         )
+
     assert len(ctx.value.errors) == 1
     assert str(ctx.value.errors[0]) == "not a valid value @ data['additional_key']"
+
+
+def test_error_reporting_on_keys():
+
+    def validate(arg: str) -> str:
+        if arg == "29 February 2021":
+            raise ValueError("not a leap year")
+        return "2020-02-29"
+
+    data = {
+        "29 February 2020": "...",
+        "29 February 2021": "...",
+    }
+
+    schema = Schema({validate: str})
+
+    with pytest.raises(MultipleInvalid) as ctx:
+        schema(data)
+
+    assert len(ctx.value.errors) == 1
+    assert str(ctx.value.errors[0]) == "not a valid value @ data['29 February 2021']"
 
 
 def test_coerce_enum():

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1801,15 +1801,15 @@ def test_error_reporting_on_keys():
             raise ValueError("not a leap year")
         return "2020-02-29"
 
-    data = {
-        "29 February 2020": "...",
-        "29 February 2021": "...",
-    }
-
     schema = Schema({validate: str})
 
     with pytest.raises(MultipleInvalid) as ctx:
-        schema(data)
+        schema(
+            {
+                "29 February 2020": "...",
+                "29 February 2021": "...",
+            }
+        )
 
     assert len(ctx.value.errors) == 1
     assert str(ctx.value.errors[0]) == "not a valid value @ data['29 February 2021']"


### PR DESCRIPTION
I refer to the bug fixed by PR #522.

I am getting a similar issue, and I note that this test would fail with **0.15.2** (but not 0.13.1):
```python
def test_key4():
    schema = Schema(
        {
            Any("name", "area"): str,
            "domain": str,
        },
        extra=REMOVE_EXTRA,  # instead of ALLOW_EXTRA
    )
    schema(
        {
            "name": "one",
            "domain": "two",
            "additional_key": "extra",
        }
    )
```

This PR offers a fix for the above, and extends the tests to all 4 possible variants of `extra=`.

Regarding the impact of this PR upon the goals of PR #479 - I note that `test_key1` and `test_key2` continue to pass.
