### PR TITLE
Preserve order of default keys

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -249,10 +249,12 @@ class Schema(object):
         )
 
         # Keys that may have defaults
-        all_default_keys = set(
-            key
-            for key in schema
-            if isinstance(key, Required) or isinstance(key, Optional)
+        all_default_keys = tuple(
+            {
+                key: None
+                for key in schema
+                if isinstance(key, Required) or isinstance(key, Optional)
+            }.keys()
         )
 
         _compiled_schema = {}


### PR DESCRIPTION
Since python3.7 dict are ordered by insertion. Sometimes the generated object matters as e.g. it will be used to serialize back to YAML and it isn't stable anymore. https://github.com/esphome/issues/issues/6846

This uses a dict as a temporary workaround to preserve the set semantics.