### PR TITLE
Allow Schema.extend to accept Schema instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,25 @@ requirements. In that case you can use `Schema.extend` to create a new
 ['age', 'name']
 ```
 
+`Schema.extend` can also accept another dictionary-based `Schema`. In that case
+the extension schema keeps its own `required` setting:
+
+```pycon
+>>> person = Schema({'name': str}, required=True)
+>>> contact = Schema({'email': str})
+>>> person_with_contact = person.extend(contact)
+>>> person_with_contact({'name': 'Ada'})
+{'name': 'Ada'}
+>>> person_with_contact({'name': 'Ada', 'email': 'ada@example.com'})
+{'name': 'Ada', 'email': 'ada@example.com'}
+>>> required_contact = Schema({'phone': str}, required=True)
+>>> person_with_phone = person.extend(required_contact)
+>>> person_with_phone({'name': 'Ada'})
+Traceback (most recent call last):
+...
+voluptuous.error.MultipleInvalid: required key not provided @ data['phone']
+```
+
 The original `Schema` remains unchanged.
 
 ### Objects

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -716,10 +716,26 @@ class Schema(object):
 
         Both schemas must be dictionary-based.
 
-        :param schema: dictionary to extend this `Schema` with
+        :param schema: dictionary, or Schema wrapping a dictionary, to extend
+            this `Schema` with
         :param required: if set, overrides `required` of this `Schema`
         :param extra: if set, overrides `extra` of this `Schema`
         """
+
+        result_required = required if required is not None else self.required
+        result_extra = extra if extra is not None else self.extra
+
+        if isinstance(schema, Schema):
+            if schema.extra != result_extra:
+                raise er.SchemaError(
+                    'Schema.extend() cannot preserve extra from the extension '
+                    'Schema when it differs from the resulting Schema extra. '
+                    'Pass child_schema.schema explicitly if you only want raw '
+                    'dict merge semantics.'
+                )
+            schema = self._normalize_schema_extension(
+                schema.schema, schema.required, result_required
+            )
 
         assert isinstance(self.schema, dict) and isinstance(
             schema, dict
@@ -762,9 +778,27 @@ class Schema(object):
 
         # recompile and send old object
         result_cls = type(self)
-        result_required = required if required is not None else self.required
-        result_extra = extra if extra is not None else self.extra
         return result_cls(result, required=result_required, extra=result_extra)
+
+    @staticmethod
+    def _normalize_schema_extension(
+        schema: Schemable, schema_required: bool, result_required: bool
+    ) -> Schemable:
+        if not isinstance(schema, dict):
+            return schema
+
+        result = {}
+        for key, value in schema.items():
+            normalized_key = key
+            if key is not Extra and not isinstance(key, Marker):
+                if schema_required:
+                    normalized_key = Required(key)
+                elif result_required:
+                    normalized_key = Optional(key)
+            result[normalized_key] = Schema._normalize_schema_extension(
+                value, schema_required, result_required
+            )
+        return result
 
 
 def _compile_scalar(schema):

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -52,6 +52,7 @@ from voluptuous import (
     Replace,
     Required,
     Schema,
+    SchemaError,
     Self,
     SomeOf,
     TooManyValid,
@@ -441,6 +442,114 @@ def test_schema_extend():
     assert isinstance(extended, Schema)
 
 
+def test_schema_extend_with_schema_instance():
+    """Verify that Schema.extend accepts a Schema wrapping a dictionary."""
+
+    base = Schema({'a': int})
+    extension = Schema({'b': str})
+    extended = base.extend(extension)
+
+    assert base.schema == {'a': int}
+    assert extension.schema == {'b': str}
+    assert extended.schema == {'a': int, 'b': str}
+
+
+def test_schema_extend_with_required_schema_instance():
+    """Verify that Schema.extend preserves required keys from a Schema."""
+
+    base = Schema({'a': int})
+    extension = Schema({'b': str}, required=True)
+    extended = base.extend(extension)
+
+    keys = list(extended.schema)
+    assert isinstance(keys[1], Required)
+    assert keys[1].schema == 'b'
+
+    with pytest.raises(MultipleInvalid, match="required key not provided"):
+        extended({'a': 1})
+
+
+def test_schema_extend_with_optional_schema_instance_required_base():
+    """Verify that Schema.extend preserves optional keys from a Schema."""
+
+    base = Schema({'a': int}, required=True)
+    extension = Schema({'b': str}, required=False)
+    extended = base.extend(extension)
+
+    keys = list(extended.schema)
+    assert isinstance(keys[1], Optional)
+    assert keys[1].schema == 'b'
+    assert extended({'a': 1}) == {'a': 1}
+
+
+def test_schema_extend_with_schema_instance_preserves_markers():
+    """Verify that Schema.extend preserves explicit marker keys."""
+
+    required = Required('required')
+    optional = Optional('optional')
+    remove = Remove('remove')
+    extension = Schema(
+        {required: int, optional: str, remove: object, Extra: object}, required=True
+    )
+    extended = Schema({}).extend(extension)
+    keys = list(extended.schema)
+
+    assert any(key is required for key in keys)
+    assert any(key is optional for key in keys)
+    assert any(key is remove for key in keys)
+    assert any(key is Extra for key in keys)
+
+
+def test_schema_extend_with_schema_instance_preserves_nested_required():
+    """Verify that Schema.extend preserves nested required keys from a Schema."""
+
+    base = Schema({})
+    extension = Schema({'parent': {'child': int}}, required=True)
+    extended = base.extend(extension)
+
+    parent_key = list(extended.schema)[0]
+    child_key = list(extended.schema[parent_key])[0]
+    assert isinstance(parent_key, Required)
+    assert isinstance(child_key, Required)
+
+    with pytest.raises(MultipleInvalid, match="required key not provided"):
+        extended({'parent': {}})
+
+
+def test_schema_extend_with_schema_instance_preserves_nested_optional():
+    """Verify that Schema.extend preserves nested optional keys from a Schema."""
+
+    base = Schema({'a': int}, required=True)
+    extension = Schema({'parent': {'child': int}}, required=False)
+    extended = base.extend(extension)
+
+    parent_key = list(extended.schema)[1]
+    child_key = list(extended.schema[parent_key])[0]
+    assert isinstance(parent_key, Optional)
+    assert isinstance(child_key, Optional)
+    assert extended({'a': 1, 'parent': {}}) == {'a': 1, 'parent': {}}
+
+
+def test_schema_extend_with_schema_instance_rejects_extra_mismatch():
+    """Verify that Schema.extend rejects incompatible extra settings."""
+
+    base = Schema({}, extra=ALLOW_EXTRA)
+    extension = Schema({'b': str})
+
+    with pytest.raises(SchemaError, match='cannot preserve extra'):
+        base.extend(extension)
+
+
+def test_schema_extend_with_non_dictionary_schema_instance_fails():
+    """Verify that Schema.extend rejects a Schema wrapping a non-dictionary."""
+
+    base = Schema({'a': int})
+    extension = Schema([int])
+
+    with pytest.raises(AssertionError, match='Both schemas must be dictionary-based'):
+        base.extend(extension)
+
+
 def test_schema_extend_overrides():
     """Verify that Schema.extend can override required/extra parameters."""
     base = Schema({'a': int}, required=True)
@@ -483,6 +592,21 @@ def test_schema_extend_handles_schema_subclass():
 
     base = S({Required('a'): int})
     extension = {Optional('b'): str}
+    extended = base.extend(extension)
+
+    expected_schema = {Required('a'): int, Optional('b'): str}
+    assert extended.schema == expected_schema
+    assert isinstance(extended, S)
+
+
+def test_schema_extend_with_schema_instance_handles_schema_subclass():
+    """Verify that Schema.extend preserves subclass type with a Schema argument."""
+
+    class S(Schema):
+        pass
+
+    base = S({Required('a'): int})
+    extension = Schema({Optional('b'): str})
     extended = base.extend(extension)
 
     expected_schema = {Required('a'): int, Optional('b'): str}


### PR DESCRIPTION
## Summary

This PR allows `Schema.extend()` to accept another dictionary-based `Schema` instance.

Previously, `Schema.extend()` only accepted raw dictionary fragments:

```python
base = Schema({"a": int})
extended = base.extend({"b": str})
```

Passing a `Schema` instance failed because `extend()` asserted that the argument itself was a dictionary:

```python
base = Schema({"a": int})
child = Schema({"b": str})

base.extend(child)
# AssertionError: Both schemas must be dictionary-based
```

This PR makes the following work:

```python
base = Schema({"a": int})
child = Schema({"b": str})

extended = base.extend(child)
assert extended.schema == {"a": int, "b": str}
```

## Required semantics

When the extension is a `Schema`, this PR preserves the child schema’s `required` behavior by normalizing plain keys before merging.

If the child schema is required, plain child keys become explicitly required:

```python
base = Schema({"a": int})
child = Schema({"b": str}, required=True)

extended = base.extend(child)
extended({"a": 1})
# raises MultipleInvalid: required key not provided @ data['b']
```

If the child schema is not required, plain child keys remain optional even when the base schema is required:

```python
base = Schema({"a": int}, required=True)
child = Schema({"b": str}, required=False)

extended = base.extend(child)
assert extended({"a": 1}) == {"a": 1}
```

The same normalization is applied recursively to nested dictionary values.

## Preserved behavior

This PR keeps existing raw dict behavior unchanged:

```python
base = Schema({"a": int}, required=True)
extended = base.extend({"b": str})
```

As before, the raw dict extension is merged directly and interpreted using the resulting schema’s settings.

Explicit marker keys are preserved and are not rewritten:

```python
Required("a")
Optional("b")
Remove("c")
Extra
```

The return type is still `type(self)`, so subclasses of `Schema` continue to work.

## Extra handling

This PR does not try to merge `extra` semantics from the extension schema.

If the extension `Schema.extra` differs from the resulting schema’s `extra`, `Schema.extend()` raises `SchemaError` with guidance to pass `child_schema.schema` explicitly when raw dict merge semantics are desired.

## Tests

Added regression coverage for:

- extending with a dictionary-based `Schema`;
- child `Schema(..., required=True)` preserving required keys;
- child `Schema(..., required=False)` staying optional under a required base schema;
- explicit `Required`, `Optional`, `Remove`, and `Extra` marker preservation;
- recursive nested dict required/optional normalization;
- incompatible `extra` settings raising `SchemaError`;
- non-dictionary `Schema` instances still raising the existing assertion;
- existing raw dict extension behavior;
- existing subclass return behavior.

Focused test command:

```bash
./.venv/bin/pytest voluptuous/tests/tests.py -k "schema_extend or subschema_extension"
```

Result:

```text
14 passed, 162 deselected
```

Closes #386 