### PR TITLE
Raise Invalid for non-numeric input to Number validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+**Fixes**:
+
+* [#539](https://github.com/alecthomas/voluptuous/pull/539): Raise `Invalid` instead of leaking `TypeError`/`ValueError` for non-numeric input to the `Number` validator
+
 ## [0.16.0]
 
 **New**:

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -996,6 +996,21 @@ def test_number_validation_with_string():
         assert False, "Did not raise Invalid for String"
 
 
+def test_number_validation_with_non_numeric():
+    """Non-numeric input raises Invalid, like an unparsable string does."""
+    schema = Schema({"number": Number(precision=6, scale=2)})
+    for value in (None, {}, [], (), b'x'):
+        try:
+            schema({"number": value})
+        except MultipleInvalid as e:
+            assert (
+                str(e)
+                == "Value must be a number enclosed with string for dictionary value @ data['number']"
+            )
+        else:
+            assert False, "Did not raise Invalid for %r" % (value,)
+
+
 def test_number_validation_with_invalid_precision_invalid_scale():
     """Test with Number with invalid precision and scale"""
     schema = Schema({"number": Number(precision=6, scale=2)})

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -1186,7 +1186,7 @@ class Number(object):
         """
         try:
             decimal_num = Decimal(number)
-        except InvalidOperation:
+        except (InvalidOperation, TypeError, ValueError):
             raise Invalid(self.msg or 'Value must be a number enclosed with string')
 
         exp = decimal_num.as_tuple().exponent


### PR DESCRIPTION
## Summary

`Number(precision, scale)` documents `:raises Invalid:` and already converts an unparsable **string** into `Invalid("Value must be a number enclosed with string")`. But other non-numeric input leaks a raw exception instead:

```python
>>> from voluptuous import Schema, Number
>>> Schema(Number(precision=6, scale=2))(None)
TypeError: conversion from NoneType to Decimal is not supported
```

`Number._get_precision_scale` only catches `InvalidOperation` from `Decimal(number)`:

```python
try:
    decimal_num = Decimal(number)
except InvalidOperation:
    raise Invalid(self.msg or 'Value must be a number enclosed with string')
```

`Decimal(...)` raises `InvalidOperation` for bad strings (`'foo'`), `TypeError` for `None`/`dict`/`set`/`bytes`, and `ValueError` for empty sequences. Only the first was handled, so `None`, `{}`, `set()`, `b'x'` leak a `TypeError`, and `[]`/`()` surface a generic message instead of `Number`'s own. The `InvalidOperation` sibling already proves the intended behaviour is `Invalid`.

## Fix

Catch `TypeError` and `ValueError` alongside `InvalidOperation` so every non-numeric input yields the documented `Invalid`:

```python
except (InvalidOperation, TypeError, ValueError):
```

The separate infinity/NaN `TypeError` (raised *after* a successful `Decimal()` conversion, with its existing `# TODO`) is outside this `try` and is unchanged.

## Verification

- Reproduced on `master` (`87825d6`): `None`/`{}`/`set()`/`b'x'` raise `TypeError`; with the fix they (and `[]`/`()`) all raise `Invalid("Value must be a number enclosed with string")`. Valid input and a custom `msg=` are unaffected; the nan/inf path still raises its `TypeError`.
- Added `test_number_validation_with_non_numeric`, mirroring `test_number_validation_with_string`; it fails before the fix and passes after.
- Full test suite: **169 passed** (168 baseline + the new test), no regressions. `flake8` clean at the change.

---

This pull request was prepared with the assistance of AI, under my direction and review.
