### PR TITLE
fix: handle non-string input in Replace validator gracefully

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -2,6 +2,7 @@
 import collections
 import copy
 import os
+import re
 from enum import Enum
 
 import pytest
@@ -2388,3 +2389,19 @@ def test_replace_non_string_input():
     replace2 = Replace('x', 'y', msg='must be a string')
     with pytest.raises(Invalid, match='must be a string'):
         replace2(123)
+
+
+def test_replace_accepts_bytes_like_input():
+    replace = Replace(re.compile(b'hello'), b'goodbye')
+    assert replace(b'hello world') == b'goodbye world'
+    assert replace(bytearray(b'hello world')) == b'goodbye world'
+    assert replace(memoryview(b'hello world')) == b'goodbye world'
+
+
+def test_replace_preserves_type_error_from_substitution():
+    def invalid_substitution(_match):
+        raise TypeError('substitution failed')
+
+    replace = Replace('hello', invalid_substitution)
+    with pytest.raises(TypeError, match='substitution failed'):
+        replace('hello world')

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -2375,3 +2375,16 @@ def test_complex_required_keys_with_specific_value_validation():
     error_msg = str(exc_info.value)
     assert "required" not in error_msg.lower()  # No "required field missing" error
     assert "value must be at most 100" in error_msg  # Range validation error
+
+
+def test_replace_non_string_input():
+    """Verify that Replace raises Invalid for non-string input."""
+    replace = Replace('hello', 'goodbye')
+    assert replace('hello world') == 'goodbye world'
+    for value in (42, None, ['hello']):
+        with pytest.raises(Invalid, match='expected string or buffer'):
+            replace(value)
+
+    replace2 = Replace('x', 'y', msg='must be a string')
+    with pytest.raises(Invalid, match='must be a string'):
+        replace2(123)

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -469,10 +469,13 @@ class Replace(object):
         self.msg = msg
 
     def __call__(self, v):
+        # Validate the input separately so TypeError from a callable
+        # substitution is not mistaken for an incompatible input value.
         try:
-            return self.pattern.sub(self.substitution, v)
+            self.pattern.match(v, 0, 0)
         except TypeError:
             raise MatchInvalid(self.msg or 'expected string or buffer')
+        return self.pattern.sub(self.substitution, v)
 
     def __repr__(self):
         return 'Replace(%r, %r, msg=%r)' % (

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -469,7 +469,10 @@ class Replace(object):
         self.msg = msg
 
     def __call__(self, v):
-        return self.pattern.sub(self.substitution, v)
+        try:
+            return self.pattern.sub(self.substitution, v)
+        except TypeError:
+            raise MatchInvalid(self.msg or 'expected string or buffer')
 
     def __repr__(self):
         return 'Replace(%r, %r, msg=%r)' % (


### PR DESCRIPTION
The Replace validator calls re.Pattern.sub() directly on the input value. When passed a non-string type (int, None, list, etc.), this raises an unhandled TypeError instead of the expected Invalid exception.

This matches the behavior of the Match validator, which already catches TypeError and raises a proper Invalid error with a descriptive message.

**Before (crashes):**
```python
>>> from voluptuous.validators import Replace
>>> Replace('hello', 'goodbye')(42)
TypeError: expected string or bytes-like object, got 'int'
```

**After:**
```python
>>> from voluptuous.validators import Replace
>>> Replace('hello', 'goodbye')(42)
voluptuous.error.MatchInvalid: expected string or buffer
```

Changes:
- Replace.\__call__ now catches TypeError and raises MatchInvalid
- Added test\_replace\_non\_string\_input covering int, None, list, and custom message cases