### PR TITLE
Raise Invalid for Infinity/NaN input to Number validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 * [#539](https://github.com/alecthomas/voluptuous/pull/539): Raise `Invalid` instead of leaking `TypeError`/`ValueError` for non-numeric input to the `Number` validator
+* [#542](https://github.com/alecthomas/voluptuous/pull/542): Raise `Invalid` instead of leaking a raw `TypeError` for `Infinity`/`NaN` input to the `Number` validator
 
 ## [0.16.0]
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1145,6 +1145,21 @@ def test_number_validation_with_non_numeric():
             assert False, "Did not raise Invalid for %r" % (value,)
 
 
+def test_number_validation_with_infinity_and_nan():
+    """Non-finite input raises Invalid, not a raw TypeError."""
+    schema = Schema({"number": Number(precision=6, scale=2)})
+    for value in ('Infinity', '-Infinity', 'NaN'):
+        try:
+            schema({"number": value})
+        except MultipleInvalid as e:
+            assert (
+                str(e)
+                == "Value must be a number enclosed with string for dictionary value @ data['number']"
+            )
+        else:
+            assert False, "Did not raise Invalid for %s" % value
+
+
 def test_number_validation_with_invalid_precision_invalid_scale():
     """Test with Number with invalid precision and scale"""
     schema = Schema({"number": Number(precision=6, scale=2)})

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -1186,9 +1186,8 @@ class Number(object):
         if isinstance(exp, int):
             return (len(decimal_num.as_tuple().digits), -exp, decimal_num)
         else:
-            # TODO: handle infinity and NaN
-            # raise Invalid(self.msg or 'Value has no precision')
-            raise TypeError("infinity and NaN have no precision")
+            # Infinity/NaN have no precision; report as Invalid, not a raw TypeError.
+            raise Invalid(self.msg or 'Value must be a number enclosed with string')
 
 
 class SomeOf(_WithSubValidators):


### PR DESCRIPTION
Fixes #541.

`Number(precision, scale)` documents `:raises Invalid:`, but `Number(precision=6, scale=2)("Infinity")` (also `"NaN"`/`"-Infinity"`) leaks a raw `TypeError("infinity and NaN have no precision")`. `Decimal(number)` succeeds for these, then `as_tuple().exponent` is a string rather than an int, so `_get_precision_scale` fell into the `else` branch that raised `TypeError`. The commented-out line there already showed the intended behaviour.

The `else` now raises `Invalid` with the same message the `InvalidOperation` sibling uses, so a non-finite value is rejected like any other unusable number. Added `test_number_validation_with_infinity_and_nan` mirroring `test_number_validation_with_string`; it fails before the change and passes after. Full suite: 168 passed, flake8 clean.

This is separate from #539, which handles `None`/`dict`/`bytes` before the `Decimal()` call and explicitly leaves this non-finite path alone.