### PR TITLE
Raise Invalid for non-finite Number values

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1010,6 +1010,16 @@ def test_number_validation_with_invalid_precision_invalid_scale():
         assert False, "Did not raise Invalid for String"
 
 
+def test_number_validation_with_non_finite_number():
+    schema = Schema({"number": Number(precision=6, scale=2)})
+    try:
+        schema({"number": 'Infinity'})
+    except MultipleInvalid as e:
+        assert str(e) == "Value has no precision for dictionary value @ data['number']"
+    else:
+        assert False, "Did not raise Invalid for Infinity"
+
+
 def test_number_validation_with_valid_precision_scale_yield_decimal_true():
     """Test with Number with valid precision and scale"""
     schema = Schema({"number": Number(precision=6, scale=2, yield_decimal=True)})

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -1193,9 +1193,7 @@ class Number(object):
         if isinstance(exp, int):
             return (len(decimal_num.as_tuple().digits), -exp, decimal_num)
         else:
-            # TODO: handle infinity and NaN
-            # raise Invalid(self.msg or 'Value has no precision')
-            raise TypeError("infinity and NaN have no precision")
+            raise Invalid(self.msg or 'Value has no precision')
 
 
 class SomeOf(_WithSubValidators):


### PR DESCRIPTION
Fixes #541.

## What changed

`Number` now rejects non-finite Decimal values such as `Infinity` and `NaN` with `Invalid` instead of leaking the internal `TypeError` from precision inspection.

## Why

`Number` is a validator and callers expect validation failures to surface as voluptuous `Invalid` / `MultipleInvalid`. Non-finite numeric strings currently escape that contract when precision or scale checking is enabled.

## Validation

- `python -m pytest voluptuous\tests\tests.py::test_number_validation_with_string voluptuous\tests\tests.py::test_number_validation_with_non_finite_number voluptuous\tests\tests.py::test_number_validation_with_invalid_precision_invalid_scale -q`
- `python -m pytest voluptuous\tests\tests.py -q`
- `python -m py_compile voluptuous\validators.py voluptuous\tests\tests.py`
- `git diff --check`