### PR TITLE
Apply value-transforming validators (e.g. Coerce) to set elements (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#523](https://github.com/alecthomas/voluptuous/pull/523): Allow Generators for `vol.In`
 * [#524](https://github.com/alecthomas/voluptuous/pull/524): Fix bug with `Any` validator and `REMOVE_EXTRA`
+* [#400](https://github.com/alecthomas/voluptuous/issues/400): Apply value-transforming validators (e.g. `Coerce`) to set/frozenset elements, matching list and dict schemas
   
 **Changes**:
 

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -687,10 +687,13 @@ class Schema(object):
 
             _compiled = [self._compile(s) for s in schema]
             errors = []
+            out = set()
             for value in data:
                 for validate in _compiled:
                     try:
-                        validate(path, value)
+                        cval = validate(path, value)
+                        if cval is not Remove:  # do not include Remove values
+                            out.add(cval)
                         break
                     except er.Invalid:
                         pass
@@ -701,7 +704,7 @@ class Schema(object):
             if errors:
                 raise er.MultipleInvalid(errors)
 
-            return data
+            return type_(out)
 
         return validate_set
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1567,6 +1567,20 @@ def test_frozenset_of_integers_and_strings():
     assert len(ctx.value.errors) == 1
 
 
+def test_coerce_in_set_is_applied():
+    # A validator that transforms its input (e.g. Coerce) must have its result
+    # reflected in the returned set, mirroring list/dict schemas. Previously the
+    # returned set kept the original, un-coerced values. See issue #400.
+    assert Schema({Coerce(int)})({'1', '2'}) == {1, 2}
+
+    result = Schema(frozenset([Coerce(int)]))(frozenset({'1', '2'}))
+    assert result == frozenset({1, 2})
+    assert isinstance(result, frozenset)
+
+    # Non-transforming validators still round-trip unchanged.
+    assert Schema({int})({1, 2}) == {1, 2}
+
+
 def test_lower_util_handles_various_inputs():
     assert Lower(3) == "3"
     assert Lower(u"3") == u"3"


### PR DESCRIPTION
## Summary

Closes #400.

A value-transforming validator inside a **set** schema was run only for its side effects, so its result was thrown away and the original values were returned:

```python
Schema(Coerce(int))("1")          # 1        (bare — coerces)
Schema([Coerce(int)])(["1","2"])  # [1, 2]   (list — coerces)
Schema({Coerce(int)})({"1","2"})  # {'1','2'}  <-- BUG: strings, not ints
```

`_compile_set.validate_set` called `validate(path, value)` purely for validation and then `return data`, discarding any transformation — unlike `_compile_sequence`, which collects each validator's return value.

## Change

Collect each validator's return value into a new set and return it as the original `set`/`frozenset` type, mirroring `_compile_sequence` (including the `Remove` handling so a validator returning `Remove` drops the element). Non-transforming validators (e.g. `Schema({int})({1, 2})`) round-trip unchanged.

```python
Schema({Coerce(int)})({"1", "2"})               # {1, 2}
Schema(frozenset([Coerce(int)]))(frozenset({"1"}))  # frozenset({1})
```

## Tests

Added `test_coerce_in_set_is_applied` (covers `set`, `frozenset`, and the unchanged non-coercion case). It fails on `master` and passes with this change. Full suite passes (170 passed); `black --check` and `flake8` are clean. Added a CHANGELOG entry.