### PR TITLE
Add __repr__ to Invalid so it surfaces the path and error type (#358)

### DIFF
--- a/voluptuous/error.py
+++ b/voluptuous/error.py
@@ -53,6 +53,9 @@ class Invalid(Error):
             output += ' for ' + self.error_type
         return output + path
 
+    def __repr__(self) -> str:
+        return '%s(%r)' % (self.__class__.__name__, str(self))
+
     def prepend(self, path: typing.List[typing.Hashable]) -> None:
         self._path = path + self.path
 

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -332,6 +332,20 @@ def test_email_validation_without_host():
     assert isinstance(ctx.value.errors[0], EmailInvalid)
 
 
+def test_invalid_repr_includes_path_and_type():
+    """`repr(Invalid)` should surface the same context as `str`, like MultipleInvalid does."""
+    with pytest.raises(MultipleInvalid) as ctx:
+        Schema({'k': int})({'k': 'x'})
+    error = ctx.value.errors[0]
+    assert isinstance(error, TypeInvalid)
+    # Previously repr fell back to the default and dropped the path/type.
+    assert (
+        repr(error) == "TypeInvalid(\"expected int for dictionary value @ data['k']\")"
+    )
+    # The nested error reprs surface in the MultipleInvalid repr too.
+    assert repr(error) in repr(ctx.value)
+
+
 @pytest.mark.parametrize(
     'input_value', ['john@voluptuous.com>', 'john!@voluptuous.org!@($*!']
 )


### PR DESCRIPTION
Fixes #358.

## Problem

`Invalid.__str__` produces an informative message including the path and error type:

```
expected int for dictionary value @ data['k']
```

But `Invalid` has no `__repr__`, so `repr()` falls back to the default exception repr and drops that context:

```python
>>> repr(err)
TypeInvalid('expected int')     # path and error_type lost
```

This matters in practice: `MultipleInvalid.__repr__` renders its `.errors` list, so inspecting or logging a `MultipleInvalid` shows a list of uninformative sub-error reprs.

## Fix

Give `Invalid` a `__repr__` that surfaces the same context `__str__` already does — matching the `__repr__` that `MultipleInvalid` already defines:

```python
def __repr__(self) -> str:
    return '%s(%r)' % (self.__class__.__name__, str(self))
```

Result:

```python
>>> repr(err)
TypeInvalid("expected int for dictionary value @ data['k']")
>>> repr(multiple)
MultipleInvalid([TypeInvalid("expected int for dictionary value @ data['k']")])
```

No validation behavior changes — only the repr of the error objects.

## Testing

- Added `test_invalid_repr_includes_path_and_type`, asserting the repr includes the path/type and that it surfaces inside the `MultipleInvalid` repr. It fails on `master` (`TypeInvalid('expected int')`) and passes with this change.
- Full suite passes (`170 passed`). `black` and `flake8` are clean on the changed files.
- One unrelated doctest (`README.md:93`) fails on this machine under Python 3.14; it fails identically without this change (the tox matrix is 3.9–3.12) and is untouched here.

---

*Disclosure: this change was prepared with the assistance of an AI tool (Claude Code). I verified the behavior, added and ran the test, ran the suite and linters, and take responsibility for the contribution and will respond to review feedback personally.*
