### PR TITLE
Don't leak TypeError from Coerce when the type is a non-class callable

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -1745,6 +1745,20 @@ def test_coerce_in_set_is_applied():
     assert Schema({int})({1, 2}) == {1, 2}
 
 
+def test_coerce_callable_marks_invalid_without_msg():
+    # Coerce accepts any callable (not just a class). When such a callable
+    # raises on bad input, the value must be marked Invalid, as the docstring
+    # promises -- the Enum-message branch used to call issubclass() on the
+    # callable and leak a raw TypeError. See the class twin Coerce(int), which
+    # already behaves this way.
+    def parse_int(v):
+        return int(v)
+
+    validate = Schema(Coerce(parse_int))
+    with raises(MultipleInvalid, 'expected parse_int'):
+        validate('foo')
+
+
 def test_lower_util_handles_various_inputs():
     assert Lower(3) == "3"
     assert Lower(u"3") == u"3"

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -145,7 +145,12 @@ class Coerce(object):
             return self.type(v)
         except (ValueError, TypeError, InvalidOperation):
             msg = self.msg or ('expected %s' % self.type_name)
-            if not self.msg and Enum and issubclass(self.type, Enum):
+            if (
+                not self.msg
+                and Enum
+                and isinstance(self.type, type)
+                and issubclass(self.type, Enum)
+            ):
                 msg += " or one of %s" % str([e.value for e in self.type])[1:-1]
             raise CoerceInvalid(msg)
 


### PR DESCRIPTION
### Problem

`Coerce` accepts any callable (`type: Union[type, Callable]`), and its docstring says a `ValueError`/`TypeError` from the constructor marks the value `Invalid`. But when the callable is a plain function (not a class), the failure path raises a raw, uncaught `TypeError` instead:

```python
from voluptuous import Schema, Coerce
import datetime

Schema(Coerce(datetime.datetime.fromisoformat))('not-a-date')
# TypeError: issubclass() arg 1 must be a class    <-- escapes; not an Invalid

def parse_int(v): return int(v)
Schema(Coerce(parse_int))('foo')
# TypeError: issubclass() arg 1 must be a class
```

`Coerce(int)('foo')` (a class) correctly yields `MultipleInvalid: expected int`. The only difference is class-vs-function, so the two are analogous — and functions are explicitly supported by the signature.

### Cause

In `Coerce.__call__`, the `except` handler calls `issubclass(self.type, Enum)` to optionally list Enum values in the message. `issubclass()` requires a class as its first argument, so when `self.type` is a function it raises `TypeError`. That call is **outside** the `try` (which only wraps `self.type(v)`), so it propagates raw, bypassing `CoerceInvalid`, error paths, and `humanize`.

Note `Coerce(func, msg="...")` didn't hit this, because `not self.msg` short-circuits before `issubclass` — only the default-message path was affected.

### Fix

Guard the Enum check with `isinstance(self.type, type)`:

```python
if not self.msg and Enum and isinstance(self.type, type) and issubclass(self.type, Enum):
```

The class path (including the Enum value-listing message, e.g. `expected Color or one of 1, 2`) is unchanged; non-class callables now produce `MultipleInvalid: expected <name>` as documented.

### Testing

Added `test_coerce_callable_marks_invalid_without_msg` (red before, green after). Full suite: 182 passed. `black`, `isort`, `flake8`, `mypy` all clean.

---

*Disclosure: authored by an AI coding agent (Claude Code) running on this account — it found the bug, ran the repro, wrote the test and this description. I review every change and am accountable for it; the verification above is real and re-runnable from the diff. If this isn't a change you want, say so and I'll close it.*
