### PR TITLE
Accept Mapping inputs for dict schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#539](https://github.com/alecthomas/voluptuous/pull/539): Raise `Invalid` instead of leaking `TypeError`/`ValueError` for non-numeric input to the `Number` validator
 * [#542](https://github.com/alecthomas/voluptuous/pull/542): Raise `Invalid` instead of leaking a raw `TypeError` for `Infinity`/`NaN` input to the `Number` validator
+* [#299](https://github.com/alecthomas/voluptuous/issues/299): Accept `Mapping` instances, not only `dict`, when validating dictionary schemas
 
 ## [0.16.0]
 

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -531,7 +531,7 @@ class Schema(object):
                 g.append(node)
 
         def validate_dict(path, data):
-            if not isinstance(data, dict):
+            if not isinstance(data, collections.abc.Mapping):
                 raise er.DictInvalid('expected a dictionary', path)
 
             errors = []
@@ -572,7 +572,7 @@ class Schema(object):
             if errors:
                 raise er.MultipleInvalid(errors)
 
-            out = data.__class__()
+            out = data.__class__() if isinstance(data, dict) else {}
             return base_validate(path, data.items(), out)
 
         return validate_dict

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -991,6 +991,25 @@ def test_schema_empty_dict():
         assert False, "Did not raise correct Invalid"
 
 
+def test_schema_accepts_mapping():
+    class QueryArgs(collections.abc.Mapping):
+        def __init__(self, data):
+            self._data = data
+
+        def __getitem__(self, key):
+            return self._data[key]
+
+        def __iter__(self):
+            return iter(self._data)
+
+        def __len__(self):
+            return len(self._data)
+
+    s = Schema({'page': Coerce(int), Optional('q', default=''): str})
+
+    assert s(QueryArgs({'page': '1'})) == {'page': 1, 'q': ''}
+
+
 def test_schema_empty_dict_key():
     """https://github.com/alecthomas/voluptuous/pull/434"""
     s = Schema({'var': []})


### PR DESCRIPTION
Fixes #299

## Reproduction
A dictionary schema currently rejects `collections.abc.Mapping` implementations that are not `dict` subclasses:

```python
from collections.abc import Mapping
from voluptuous import Schema

class QueryArgs(Mapping):
    def __init__(self, data):
        self._data = data
    def __getitem__(self, key):
        return self._data[key]
    def __iter__(self):
        return iter(self._data)
    def __len__(self):
        return len(self._data)

Schema({"page": int})(QueryArgs({"page": 1}))
```

On current `master` this raises `MultipleInvalid: expected a dictionary`.

## Root cause
`Schema._compile_dict()` only accepted `dict` instances even though the schema type already treats `collections.abc.Mapping` as a valid dictionary-like schema and mappings expose the `.items()` / membership APIs used by validation.

## Fix
Accept `collections.abc.Mapping` inputs in dictionary schemas. Existing `dict` and `dict` subclass output behavior is preserved; generic `Mapping` inputs produce a plain `dict`, avoiding assumptions that arbitrary mapping classes can be constructed empty and mutated.

## Compatibility notes
The existing error message for non-mapping inputs remains `expected a dictionary`. This only broadens accepted inputs for objects implementing the standard Mapping protocol.

## Validation
- Minimal reproducer failed before the fix with `MultipleInvalid: expected a dictionary` and succeeds after the fix.
- Regression check with fix reverted: `python -m pytest voluptuous\tests\tests.py::test_schema_accepts_mapping -q` fails with `MultipleInvalid: expected a dictionary`.
- Targeted regression with fix: `python -m pytest voluptuous\tests\tests.py::test_schema_accepts_mapping -q` -> 1 passed.
- Full suite: `python -m pytest` -> 183 passed.
- Formatting/lint/type checks: `black --check voluptuous\schema_builder.py voluptuous\tests\tests.py` -> unchanged; `isort --check voluptuous\schema_builder.py voluptuous\tests\tests.py` -> passed; `flake8 --doctests voluptuous\schema_builder.py voluptuous\tests\tests.py` -> passed; `mypy voluptuous` -> success, no issues found in 10 source files (mypy 2.3.0 also notes the repo's configured `python_version = 3.9` is below its supported range on Python 3.13).