### PR TITLE
Raise LengthInvalid (not RangeInvalid) for non-sized values in Length

### DIFF
--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -33,6 +33,7 @@ from voluptuous import (
     IsDir,
     IsFile,
     Length,
+    LengthInvalid,
     Literal,
     LiteralInvalid,
     Marker,
@@ -870,8 +871,10 @@ def test_length_too_long():
 def test_length_invalid():
     v = None
     s = Schema(Length(min=0, max=2))
-    with pytest.raises(MultipleInvalid):
+    with pytest.raises(MultipleInvalid) as ctx:
         s(v)
+    # a value with no length must be reported as a LengthInvalid, not a RangeInvalid
+    assert isinstance(ctx.value.errors[0], LengthInvalid)
 
 
 def test_equal():

--- a/voluptuous/validators.py
+++ b/voluptuous/validators.py
@@ -773,7 +773,7 @@ class Length(object):
 
         # Objects that have no length e.g. None or strings will raise TypeError
         except TypeError:
-            raise RangeInvalid(self.msg or 'invalid value or type')
+            raise LengthInvalid(self.msg or 'invalid value or type')
 
     def __repr__(self):
         return 'Length(min=%s, max=%s)' % (self.min, self.max)


### PR DESCRIPTION
## Summary

`Length.__call__` raises `LengthInvalid` for its length checks, but the `except TypeError` handler raises `RangeInvalid`:

```python
def __call__(self, v):
    try:
        if self.min is not None and len(v) < self.min:
            raise LengthInvalid(self.msg or 'length of value must be at least %s' % self.min)
        if self.max is not None and len(v) > self.max:
            raise LengthInvalid(self.msg or 'length of value must be at most %s' % self.max)
        return v
    # Objects that have no length e.g. None or strings will raise TypeError
    except TypeError:
        raise RangeInvalid(self.msg or 'invalid value or type')   # <-- should be LengthInvalid
```

When a value with no `len()` (e.g. `None`, or an `int`) is passed to a `Length` validator, the error is reported as a **range** error rather than a **length** error — inconsistent with the validator's own two other error paths.

This looks like a copy-paste leftover from the `Clamp` validator directly above, which is genuinely a range operation and correctly raises `RangeInvalid` in its own `except TypeError`.

## Fix

```diff
     except TypeError:
-        raise RangeInvalid(self.msg or 'invalid value or type')
+        raise LengthInvalid(self.msg or 'invalid value or type')
```

`LengthInvalid` is already imported at the top of the module.

## Tests

Tightened `test_length_invalid` to assert the raised error is a `LengthInvalid`. It fails on the previous behavior (`RangeInvalid`) and passes with the fix. Full suite: 181 passed.
