### PR TITLE
Fix: In _compile_sequence's validate_sequence (schema_builder.py), the loop...

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -343,6 +343,14 @@ class Schema(object):
                     except er.Invalid as e:
                         if len(e.path) > len(key_path):
                             raise
+                        # This candidate key schema/validator rejected the
+                        # provided key outright -- the data's key has
+                        # nothing to do with this candidate, as opposed to
+                        # a key that matched but whose value was wrong.
+                        # Tag it so callers such as _compile_sequence's
+                        # list-of-dict-alternatives heuristic can tell the
+                        # two situations apart.
+                        e._key_shape_mismatch = True
                         if not error or len(e.path) > len(error.path):
                             error = e
                         continue
@@ -395,7 +403,9 @@ class Schema(object):
                     elif error:
                         errors.append(error)
                     else:
-                        errors.append(er.Invalid('extra keys not allowed', key_path))
+                        no_candidate_error = er.Invalid('extra keys not allowed', key_path)
+                        no_candidate_error._key_shape_mismatch = True
+                        errors.append(no_candidate_error)
 
             # for any required keys left that weren't found and don't have defaults:
             for key in required_keys:
@@ -404,7 +414,9 @@ class Schema(object):
                     if hasattr(key, 'msg') and key.msg
                     else 'required key not provided'
                 )
-                errors.append(er.RequiredFieldInvalid(msg, path + [key]))
+                missing_key_error = er.RequiredFieldInvalid(msg, path + [key])
+                missing_key_error._key_shape_mismatch = True
+                errors.append(missing_key_error)
             if errors:
                 raise er.MultipleInvalid(errors)
 
@@ -822,27 +834,31 @@ def _is_key_shape_mismatch(invalid, index_path):
     silently falling through to the remaining alternatives.
 
     A dict/mapping validator breaks that assumption: it always reports
-    "extra keys not allowed" and "required key not provided" errors one
-    level deeper than the path it was given (it names the offending key),
-    even when none of the alternative's keys have anything to do with the
-    data's keys, i.e. the alternative doesn't match the data's shape at
-    all. Recognize exactly those two error kinds -- and only when they
-    occur at that one-level-deeper depth -- as shape mismatches so the
-    caller can keep trying the remaining alternatives instead of giving
-    up immediately. Any other error at that depth (e.g. a wrong value
-    for a key that *was* matched) is left alone and still aborts the
-    search, since that heuristic is correct in that case.
+    key-related errors ("extra keys not allowed", "required key not
+    provided", or a rejection from a key validator/schema such as
+    ``In(...)`` or ``Match(...)``) one level deeper than the path it was
+    given (it names the offending key), even when none of the
+    alternative's keys have anything to do with the data's keys, i.e. the
+    alternative doesn't match the data's shape at all.
+
+    ``validate_mapping`` tags every error of that kind with
+    ``_key_shape_mismatch`` at the point it's raised/constructed (rather
+    than this function trying to reverse-engineer it from the error's
+    class or message, which can't distinguish a literal-key "extra keys
+    not allowed" from a key-validator's own -- differently classed and
+    worded -- rejection). Recognize exactly those tagged errors -- and
+    only when they occur at that one-level-deeper depth -- as shape
+    mismatches so the caller can keep trying the remaining alternatives
+    instead of giving up immediately. Any other error at that depth (e.g.
+    a wrong value for a key that *was* matched) is left alone and still
+    aborts the search, since that heuristic is correct in that case.
     """
     sub_errors = (
         invalid.errors if isinstance(invalid, er.MultipleInvalid) else [invalid]
     )
     expected_depth = len(index_path) + 1
     return all(
-        len(sub.path) == expected_depth
-        and (
-            isinstance(sub, er.RequiredFieldInvalid)
-            or (type(sub) is er.Invalid and sub.error_message == 'extra keys not allowed')
-        )
+        len(sub.path) == expected_depth and getattr(sub, '_key_shape_mismatch', False)
         for sub in sub_errors
     )
 

--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -619,7 +619,9 @@ class Schema(object):
                             out.append(cval)
                         break
                     except er.Invalid as e:
-                        if len(e.path) > len(index_path):
+                        if len(e.path) > len(index_path) and not _is_key_shape_mismatch(
+                            e, index_path
+                        ):
                             raise
                         invalid = e
                 else:
@@ -804,6 +806,45 @@ class Schema(object):
                 value, schema_required, result_required
             )
         return result
+
+
+def _is_key_shape_mismatch(invalid, index_path):
+    """Whether `invalid` reflects a dict-schema alternative whose overall
+    *shape* doesn't match the data at all, as opposed to one whose shape
+    matched but a nested value was specifically wrong.
+
+    ``validate_sequence`` tries each schema alternative for a given
+    sequence item and, by default, stops and re-raises as soon as an
+    alternative's error is reported deeper than ``index_path`` -- the
+    assumption being that a deeper path means the alternative's top-level
+    type matched and a nested detail is what's actually wrong, so
+    surfacing that specific error immediately is more helpful than
+    silently falling through to the remaining alternatives.
+
+    A dict/mapping validator breaks that assumption: it always reports
+    "extra keys not allowed" and "required key not provided" errors one
+    level deeper than the path it was given (it names the offending key),
+    even when none of the alternative's keys have anything to do with the
+    data's keys, i.e. the alternative doesn't match the data's shape at
+    all. Recognize exactly those two error kinds -- and only when they
+    occur at that one-level-deeper depth -- as shape mismatches so the
+    caller can keep trying the remaining alternatives instead of giving
+    up immediately. Any other error at that depth (e.g. a wrong value
+    for a key that *was* matched) is left alone and still aborts the
+    search, since that heuristic is correct in that case.
+    """
+    sub_errors = (
+        invalid.errors if isinstance(invalid, er.MultipleInvalid) else [invalid]
+    )
+    expected_depth = len(index_path) + 1
+    return all(
+        len(sub.path) == expected_depth
+        and (
+            isinstance(sub, er.RequiredFieldInvalid)
+            or (type(sub) is er.Invalid and sub.error_message == 'extra keys not allowed')
+        )
+        for sub in sub_errors
+    )
 
 
 def _compile_scalar(schema):

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -768,6 +768,40 @@ def test_fix_157():
         s(['four'])
 
 
+def test_fix_142_list_of_dict_alternatives():
+    """A list of dict-schema alternatives should try every alternative
+    against each item, not give up after the first alternative whose
+    keys don't match the item's shape.
+
+    https://github.com/alecthomas/voluptuous/issues/142
+    """
+    # Case 0: neither alternative matches every item on its own, but each
+    # item matches a different alternative -- this must validate.
+    schema = Schema([{1: str}, {2: str}])
+    assert schema([{1: 'one'}, {2: 'two'}]) == [{1: 'one'}, {2: 'two'}]
+
+    # Case 1: the first item *does* match the first alternative's key,
+    # but its value is the wrong type. That's a real, specific error and
+    # must be reported as such -- not swallowed in favor of trying the
+    # second alternative against the first item too.
+    schema = Schema([{1: bool}, {2: str}])
+    with pytest.raises(
+        MultipleInvalid, match=r"expected bool for dictionary value @ data\[0\]\[1\]"
+    ):
+        schema([{1: 'one'}, {2: 'two'}])
+
+    # 3+ alternatives: the fix must not be narrowly special-cased to
+    # exactly two alternatives.
+    schema = Schema([{1: str}, {2: str}, {3: str}])
+    data = [{1: 'a'}, {2: 'b'}, {3: 'c'}]
+    assert schema(data) == data
+
+    # A required key missing from an item is also a shape mismatch and
+    # should fall through to the next alternative.
+    schema = Schema([{Required(1): str}, {Required(2): str}])
+    assert schema([{2: 'two'}]) == [{2: 'two'}]
+
+
 def test_range_inside():
     s = Schema(Range(min=0, max=10))
     assert 5 == s(5)

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -801,6 +801,26 @@ def test_fix_142_list_of_dict_alternatives():
     schema = Schema([{Required(1): str}, {Required(2): str}])
     assert schema([{2: 'two'}]) == [{2: 'two'}]
 
+    # Dict alternatives keyed by a *key validator* (In, Match, etc.),
+    # rather than a literal key, must also fall through correctly: a
+    # rejection from the key validator itself is still a shape mismatch,
+    # not a real value error.
+    schema = Schema([{In(['a', 'b']): str}, {In(['c', 'd']): str}])
+    data = [{'a': 'x'}, {'c': 'y'}]
+    assert schema(data) == data
+
+    schema = Schema([{Match('^a'): str}, {Match('^c'): str}])
+    data = [{'aa': 'x'}, {'cc': 'y'}]
+    assert schema(data) == data
+
+    # And the same key-validator case still reports a real value error
+    # correctly instead of swallowing it.
+    schema = Schema([{In(['a', 'b']): int}, {In(['c', 'd']): str}])
+    with pytest.raises(
+        MultipleInvalid, match=r"expected int for dictionary value @ data\[0\]\['a'\]"
+    ):
+        schema([{'a': 'not an int'}, {'c': 'y'}])
+
 
 def test_range_inside():
     s = Schema(Range(min=0, max=10))


### PR DESCRIPTION
## Summary
Instead of trying to reverse-engineer 'is this a key-shape-mismatch error' from an error's class/message downstream, validate_mapping now tags every error it constructs that genuinely represents 'this candidate key didn't match the data's key at all' with a `_key_shape_mismatch = True` marker attribute, at each of the three points such errors are created: (1) when a key candidate's ckey() call rejects the key (covers key validators like In/Match generically, not just literal keys), (2) when no candidate matched and 'extra keys not allowed' is raised, (3) when a required key is missing entirely. _is_key_shape_mismatch in schema_builder.py now just checks for that marker plus depth, so it generically covers every source of 'key didn't match' rather than special-casing specific error text/classes. Value-validation errors (a key that WAS matched but whose value is wrong) are never tagged, so the heuristic still correctly aborts the alternative search for genuine value-type errors like Case 1 in the issue.

## Problem
alecthomas/voluptuous issue reference: alecthomas/voluptuous#142

## Root Cause
In _compile_sequence's validate_sequence (schema_builder.py), the loop over schema alternatives for a list item aborts early via `if len(e.path) > len(index_path): raise` whenever an alternative's error path is one level deeper than the item's own path -- intended to mean 'top-level shape matched, nested detail is wrong, surface it immediately'. But validate_mapping (the dict validator) always reports key-related failures ('extra keys not allowed', missing required key, or a key validator/schema like In()/Match() rejecting the key) exactly one level deeper than the path it was given, even when the alternative's shape doesn't match the data at all. The prior attempt patched this by recognizing two specific error shapes (plain 'extra keys not allowed' Invalid and RequiredFieldInvalid) via message/class inspection in a new _is_key_shape_mismatch helper, but this missed the case where a dict alternative uses a key validator (In, Match, etc.) instead of a literal key: that rejection surfaces as the key validator's own differently-classed, differently-worded Invalid (e.g. InInvalid) at the same depth, which the message/class-based check couldn't recognize as a shape mismatch.

## Testing
PASS - full suite: 183 passed (including tests.md doctests); test_fix_142_list_of_dict_alternatives extended to cover: Case 0 (issue's reported bug) success, Case 1 (genuine value-type error) still correctly raised, 3-alternative case, Required-key shape mismatch, and the new key-validator cases (In and Match, both success and a real value-error-not-swallowed case). The 2 pre-existing --doctest-modules failures (Schema._compile_dict, Remove) were confirmed identical on both the base commit and this change via git stash comparison, so they are unrelated pre-existing issues, not a regression.

## Related Issue
alecthomas/voluptuous#142
