### PR TITLE
Fix Object schema silently dropping every key on plain dict data

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -914,7 +914,17 @@ def _iterate_object(obj):
     """Return iterator over object attributes. Respect objects with
     defined __slots__.
 
+    A plain mapping has no __dict__ of its own to introspect, so vars()
+    raises TypeError on it and it falls through to yielding nothing,
+    silently treating every one of its entries as absent. Reading its
+    items directly keeps Object's "same behavior as a dictionary
+    validator" promise instead of dropping every key it's given.
+
     """
+    if isinstance(obj, collections.abc.Mapping):
+        for item in obj.items():
+            yield item
+        return
     d = {}
     try:
         d = vars(obj)

--- a/voluptuous/tests/tests.py
+++ b/voluptuous/tests/tests.py
@@ -2082,6 +2082,17 @@ def test_object():
     pytest.raises(MultipleInvalid, s, 345)
 
 
+def test_object_with_dict_data():
+    # Object has no cls set here, so it accepts any data, including a plain
+    # dict rather than a real instance with a __dict__ of its own. That used
+    # to make _iterate_object come up empty for it, so every key looked
+    # "missing" no matter what the dict actually held.
+    s = Schema({'test': (Object({'ok': 1}),)}, required=True)
+    assert s({'test': ({'ok': 1},)}) == {'test': ({'ok': 1},)}
+    pytest.raises(MultipleInvalid, s, {'test': ({},)})
+    pytest.raises(MultipleInvalid, s, {'test': ({'ok': 2},)})
+
+
 def test_exception():
     s = Schema(None)
     with pytest.raises(MultipleInvalid) as ctx:


### PR DESCRIPTION
Fixes #445.

Object() without a cls set accepts any data type, since the isinstance check against schema.cls is skipped when cls is UNDEFINED. That means a plain dict can reach validate_object just fine, but _iterate_object doesn't know what to do with one: it tries vars(obj), which raises TypeError on a dict (dicts keep their entries in their own storage, not in __dict__), falls back to checking for _asdict (namedtuples), finds neither, and quietly yields nothing. Every key the dict actually has then looks "missing" to the validator, which is exactly the confusing report in #445.

Object's own docstring says it should have "the same behavior as dictionary validator but work with object attributes", so reading a Mapping's items directly when that's what got passed in seems like the right fix rather than a special case. Added a regression test next to the existing test_object, covering the exact repro from the issue plus a couple of surrounding cases (empty dict, wrong value).

Ran the full suite locally, 183 passed. Confirmed the new test fails on the unpatched code with the same "required key not provided" error from the issue, and passes with the fix.